### PR TITLE
ページネーションに現在のページ数表示を追加

### DIFF
--- a/private-wiki/resources/views/home.blade.php
+++ b/private-wiki/resources/views/home.blade.php
@@ -57,8 +57,21 @@
             </a>
         @endforeach
     </div>
-    <div class="mt-6 flex justify-center">
-        {{ $notes->links() }}
+    <div class="mt-6">
+        {{-- 現在のページ数表示 --}}
+        @if($notes->hasPages())
+            <div class="text-center mb-4">
+                <span class="text-sm text-gray-600">
+                    ページ {{ $notes->currentPage() }} / {{ $notes->lastPage() }} 
+                    （全 {{ $notes->total() }} 件中 {{ $notes->firstItem() }}-{{ $notes->lastItem() }} 件を表示）
+                </span>
+            </div>
+        @endif
+        
+        {{-- ページネーションリンク --}}
+        <div class="flex justify-center">
+            {{ $notes->links() }}
+        </div>
     </div>
 
     <script>


### PR DESCRIPTION
## 概要
イシュー #3 の対応として、ページネーション機能に現在のページ数を明確に表示する機能を追加しました。

## 変更内容
- 「ページ X / Y」形式で現在のページ数と総ページ数を表示
- 「全 Z 件中 A-B 件を表示」で表示範囲も併記
- ページが複数ある場合のみ表示される条件分岐を追加
- 日本語でのユーザーフレンドリーな表示

## 実装詳細
- `home.blade.php` にページ情報表示用の HTML を追加
- Laravel の Paginator メソッドを使用：
  - `currentPage()` - 現在のページ番号
  - `lastPage()` - 総ページ数
  - `total()` - 全件数
  - `firstItem()`, `lastItem()` - 表示範囲

## テスト計画
- [ ] 記事が10件以上ある状態でページネーションが正しく表示されることを確認
- [ ] ページ遷移時に現在のページ数が正しく更新されることを確認
- [ ] 検索結果でもページネーション表示が正常に動作することを確認

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)