### PR TITLE
[Issue #6] ノートの編集・削除機能を実装

### DIFF
--- a/private-wiki/resources/views/notes.blade.php
+++ b/private-wiki/resources/views/notes.blade.php
@@ -19,4 +19,14 @@
     <div class="bg-white p-4 rounded shadow prose prose-slate max-w-none">
         {!! $note->body !!}
     </div>
+    
+    <div class="mt-4 flex gap-2">
+        <a href="{{ route('notes.edit', $note->id) }}" class="bg-yellow-500 text-white px-4 py-2 rounded hover:bg-yellow-600">編集</a>
+        <form action="{{ route('notes.destroy', $note->id) }}" method="POST" class="inline" onsubmit="return confirm('このノートを削除してもよろしいですか？')">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">削除</button>
+        </form>
+        <a href="{{ url('/') }}" class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">戻る</a>
+    </div>
 @endsection

--- a/private-wiki/resources/views/notes/edit.blade.php
+++ b/private-wiki/resources/views/notes/edit.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app')
+
+@section('title', 'メモを編集')
+
+@section('content')
+    <h1 class="text-2xl font-bold mb-4">メモを編集</h1>
+    <form action="{{ route('notes.update', $note->id) }}" method="POST">
+        @csrf
+        @method('PUT')
+        {{-- タイトル入力 --}}
+        <div class="mb-4">
+            <label for="title" class="block text-gray-700 font-bold mb-2">タイトル</label>
+            <input type="text" name="title" id="title" value="{{ old('title', $note->title) }}" class="w-full border-gray-300 rounded px-4 py-2" placeholder="タイトルを入力してください">
+        </div>
+
+        {{-- タグ入力 --}}
+        <div class="mb-4">
+            <label for="tags" class="block text-gray-700 font-bold mb-2">タグ</label>
+            <input type="text" name="tags" id="tags" value="{{ old('tags', $tagNames) }}" class="w-full border-gray-300 rounded px-4 py-2" placeholder="タグをカンマ区切りで入力してください">
+        </div>
+
+        {{-- ボディ入力 --}}
+        <div class="mb-4">
+            <label for="body" class="block text-gray-700 font-bold mb-2">内容</label>
+            <textarea name="body" id="body" rows="10" class="w-full border-gray-300 rounded px-4 py-2" placeholder="内容を入力してください">{{ old('body', $note->body) }}</textarea>
+        </div>
+
+        {{-- 保存・キャンセルボタン --}}
+        <div class="flex gap-2">
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">更新</button>
+            <a href="{{ route('notes.show', $note->id) }}" class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">キャンセル</a>
+        </div>
+    </form>
+
+    <script>
+        // タイトルとタグのinputでエンターキー押下時のフォーム送信を阻止
+        document.getElementById('title').addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+            }
+        });
+
+        document.getElementById('tags').addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+            }
+        });
+    </script>
+@endsection

--- a/private-wiki/routes/web.php
+++ b/private-wiki/routes/web.php
@@ -9,6 +9,9 @@ Route::get('/', [NoteController::class, 'index']);
 Route::get('/notes/create', [NoteController::class, 'create'])->name('notes.create');
 Route::post('/notes', [NoteController::class, 'store'])->name('notes.store');
 Route::get('/notes/{id}', [NoteController::class, 'show'])->name('notes.show');
+Route::get('/notes/{id}/edit', [NoteController::class, 'edit'])->name('notes.edit');
+Route::put('/notes/{id}', [NoteController::class, 'update'])->name('notes.update');
+Route::delete('/notes/{id}', [NoteController::class, 'destroy'])->name('notes.destroy');
 
 // タグ候補API
 Route::get('/tags', [TagController::class, 'index']);


### PR DESCRIPTION
## Summary
イシュー #6 で要求されたノートの編集・削除機能を実装しました。

- NoteControllerにedit, update, destroyメソッドを追加
- 編集フォーム(edit.blade.php)を作成  
- ノート詳細画面に編集・削除ボタンを追加
- 削除時の確認ダイアログを実装
- 削除後のリダイレクト先を修正

## Test plan
- [ ] ノート詳細画面で編集ボタンが表示されることを確認
- [ ] 編集フォームでノートの内容が正しく更新されることを確認
- [ ] 削除ボタンで確認ダイアログが表示されることを確認
- [ ] 削除実行後にホーム画面にリダイレクトされることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)