### PR TITLE
[Issue #1] 記事作成時のタグを検索と同じにする

### DIFF
--- a/private-wiki/public/css/app.css
+++ b/private-wiki/public/css/app.css
@@ -554,6 +554,40 @@ video {
   display: none;
 }
 
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
 .prose {
   color: var(--tw-prose-body);
   max-width: 65ch;
@@ -1272,8 +1306,16 @@ video {
   height: 2rem;
 }
 
+.max-h-40 {
+  max-height: 10rem;
+}
+
 .min-h-screen {
   min-height: 100vh;
+}
+
+.min-h-\[2\.5rem\] {
+  min-height: 2.5rem;
 }
 
 .w-16 {
@@ -1302,6 +1344,10 @@ video {
 
 .w-8 {
   width: 2rem;
+}
+
+.min-w-32 {
+  min-width: 8rem;
 }
 
 .max-w-none {
@@ -1436,6 +1482,10 @@ video {
   margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
 }
 
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1470,6 +1520,10 @@ video {
 
 .border {
   border-width: 1px;
+}
+
+.border-0 {
+  border-width: 0px;
 }
 
 .border-none {
@@ -1575,6 +1629,10 @@ video {
   background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
 }
 
+.bg-transparent {
+  background-color: transparent;
+}
+
 .bg-opacity-50 {
   --tw-bg-opacity: 0.5;
 }
@@ -1585,6 +1643,10 @@ video {
 
 .p-6 {
   padding: 1.5rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
 }
 
 .px-2 {
@@ -1807,9 +1869,19 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
 .ring-gray-300 {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(209 213 219 / var(--tw-ring-opacity, 1));
+}
+
+.blur {
+  --tw-blur: blur(8px);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .filter {
@@ -1854,15 +1926,31 @@ video {
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
+.focus-within\:border-blue-500:focus-within {
+  --tw-border-opacity: 1;
+  border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
+}
+
 .focus-within\:ring-2:focus-within {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
+.focus-within\:ring-1:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .focus-within\:ring-blue-400:focus-within {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
+}
+
+.focus-within\:ring-blue-500:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
 }
 
 .hover\:bg-blue-100:hover {
@@ -1958,6 +2046,12 @@ video {
 .focus\:ring:focus {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-0:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 

--- a/private-wiki/resources/views/components/tag-input.blade.php
+++ b/private-wiki/resources/views/components/tag-input.blade.php
@@ -1,0 +1,149 @@
+@props(['name' => 'tags', 'value' => '', 'placeholder' => 'タグを入力してください'])
+
+<div class="mt-1">
+    <div id="{{ $name }}-container" class="flex flex-wrap items-center gap-1 p-2 border border-gray-300 rounded-md focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500 bg-white min-h-[2.5rem]">
+        <input type="text" 
+               id="{{ $name }}-input" 
+               placeholder="{{ $placeholder }}" 
+               class="flex-1 min-w-32 border-0 outline-none focus:ring-0 bg-transparent"
+               autocomplete="off">
+    </div>
+    <input type="hidden" name="{{ $name }}" id="{{ $name }}-hidden" value="{{ $value }}">
+    <ul id="{{ $name }}-suggestions" class="hidden absolute z-10 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-40 overflow-y-auto mt-1"></ul>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const tagContainer = document.getElementById('{{ $name }}-container');
+    const tagInput = document.getElementById('{{ $name }}-input');
+    const tagSuggestions = document.getElementById('{{ $name }}-suggestions');
+    const tagHidden = document.getElementById('{{ $name }}-hidden');
+    let tags = [];
+
+    // 初期値の設定
+    if (tagHidden.value) {
+        tags = tagHidden.value.split(',').filter(tag => tag.trim());
+        renderTags();
+    }
+
+    function renderTags() {
+        // すべてのタグを消去
+        tagContainer.querySelectorAll('.tag').forEach(tag => tag.remove());
+
+        // タグを順に表示
+        tags.forEach((tag, index) => {
+            const span = document.createElement('span');
+            span.className = 'tag bg-blue-200 text-blue-800 text-xs px-2 py-1 rounded flex items-center gap-1 mr-2';
+            span.textContent = tag;
+
+            const remove = document.createElement('button');
+            remove.type = 'button';
+            remove.textContent = '×';
+            remove.className = 'ml-1 text-xs text-red-500';
+            remove.onclick = () => {
+                tags.splice(index, 1);
+                renderTags();
+            };
+
+            span.appendChild(remove);
+            tagContainer.insertBefore(span, tagInput);
+        });
+
+        // hidden フィールドに値をセット
+        tagHidden.value = tags.join(',');
+    }
+
+    function tryCombineTags() {
+        if (tags.length >= 3) {
+            const last = tags.length - 1;
+            if (tags[last - 1] === '::') {
+                const combined = `${tags[last - 2]}::${tags[last]}`;
+                tags.splice(last - 2, 3, combined);
+            }
+        }
+    }
+
+    tagInput.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' && !e.isComposing) {
+            e.preventDefault();
+            const value = tagInput.value.trim();
+            if (!value) return;
+
+            if (!tags.includes(value)) {
+                tags.push(value);
+                tryCombineTags();
+                renderTags();
+            }
+            
+            // 重複でも入力欄は常にクリア
+            setTimeout(() => {
+                tagInput.value = '';
+                tagInput.dispatchEvent(new Event('input'));
+            }, 0);
+            tagSuggestions.innerHTML = '';
+            tagSuggestions.classList.add('hidden');
+        }
+    });
+
+    // タグ候補クリック時
+    tagSuggestions.addEventListener('mousedown', function (e) {
+        if (e.target.tagName === 'LI') {
+            const tag = e.target.textContent.trim();
+            if (tag && !tags.includes(tag)) {
+                tags.push(tag);
+                tryCombineTags();
+                renderTags();
+            }
+            // 重複でも入力欄は常にクリア
+            tagInput.value = '';
+            tagSuggestions.innerHTML = '';
+            tagSuggestions.classList.add('hidden');
+        }
+    });
+
+    // 候補表示
+    tagInput.addEventListener('input', function () {
+        const query = tagInput.value.trim();
+        if (!query) {
+            tagSuggestions.innerHTML = '';
+            tagSuggestions.classList.add('hidden');
+            return;
+        }
+
+        fetch(`/tags?query=${encodeURIComponent(query)}`)
+            .then(res => res.json())
+            .then(data => {
+                tagSuggestions.innerHTML = '';
+                let hasSuggestions = false;
+
+                data.forEach(tag => {
+                    if (!tags.includes(tag.name)) {
+                        const li = document.createElement('li');
+                        li.textContent = tag.name;
+                        li.className = 'px-2 py-1 cursor-pointer hover:bg-blue-100';
+                        tagSuggestions.appendChild(li);
+                        hasSuggestions = true;
+                    }
+                });
+
+                if (hasSuggestions) {
+                    tagSuggestions.classList.remove('hidden');
+                } else {
+                    tagSuggestions.classList.add('hidden');
+                }
+            })
+            .catch(err => {
+                console.error('タグ候補の取得に失敗しました:', err);
+                tagSuggestions.innerHTML = '';
+                tagSuggestions.classList.add('hidden');
+            });
+    });
+
+    // フォーカス外れたら候補を隠す
+    tagInput.addEventListener('blur', function() {
+        setTimeout(() => {
+            tagSuggestions.classList.add('hidden');
+        }, 200);
+    });
+});
+</script>

--- a/private-wiki/resources/views/home.blade.php
+++ b/private-wiki/resources/views/home.blade.php
@@ -120,15 +120,20 @@
     }
 
     tagInput.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' && !e.isComposing) {
             e.preventDefault();
             const value = tagInput.value.trim();
             if (!value) return;
 
             tags.push(value);  // タグを追加
-            tagInput.value = ''; // 入力欄をクリア
             tryCombineTags();  // 条件がそろえば結合
             renderTags();
+
+            // 入力欄を確実にクリア
+            setTimeout(() => {
+                tagInput.value = '';
+                tagInput.dispatchEvent(new Event('input'));
+            }, 0);
 
             // 検索候補をクリアして非表示にする
             tagSuggestions.innerHTML = '';
@@ -144,7 +149,12 @@
                 tags.push(tag);
                 tryCombineTags();
                 renderTags();
-                tagInput.value = '';
+                
+                // 入力欄を確実にクリア
+                setTimeout(() => {
+                    tagInput.value = '';
+                    tagInput.dispatchEvent(new Event('input'));
+                }, 0);
                 tagSuggestions.innerHTML = '';
                 tagSuggestions.classList.add('hidden');
             }

--- a/private-wiki/resources/views/notes/create.blade.php
+++ b/private-wiki/resources/views/notes/create.blade.php
@@ -20,9 +20,9 @@
         </div>
 
         {{-- タグ入力 --}}
-        <div class="mb-4">
-            <label for="tags" class="block text-gray-700 font-bold mb-2">タグ</label>
-            <input type="text" name="tags" id="tags" value="{{ old('tags') }}" maxlength="1000" class="w-full border-gray-300 rounded px-4 py-2 @error('tags') border-red-500 @enderror" placeholder="タグをカンマ区切りで入力してください">
+        <div class="mb-4 relative">
+            <label for="tags-input" class="block text-gray-700 font-bold mb-2">タグ</label>
+            <x-tag-input name="tags" :value="old('tags')" placeholder="タグを入力してください（Enterで追加）" />
             <div class="text-sm text-gray-500 mt-1">各タグは50文字以内、最大20個まで。文字、数字、アンダースコア、ハイフンが使用可能。</div>
             @error('tags')
                 <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
@@ -44,14 +44,8 @@
     </form>
 
     <script>
-        // タイトルとタグのinputでエンターキー押下時のフォーム送信を阻止
+        // タイトルのinputでエンターキー押下時のフォーム送信を阻止
         document.getElementById('title').addEventListener('keydown', function(e) {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-            }
-        });
-
-        document.getElementById('tags').addEventListener('keydown', function(e) {
             if (e.key === 'Enter') {
                 e.preventDefault();
             }

--- a/private-wiki/resources/views/notes/edit.blade.php
+++ b/private-wiki/resources/views/notes/edit.blade.php
@@ -21,9 +21,9 @@
         </div>
 
         {{-- タグ入力 --}}
-        <div class="mb-4">
-            <label for="tags" class="block text-gray-700 font-bold mb-2">タグ</label>
-            <input type="text" name="tags" id="tags" value="{{ old('tags', $tagNames) }}" maxlength="1000" class="w-full border-gray-300 rounded px-4 py-2 @error('tags') border-red-500 @enderror" placeholder="タグをカンマ区切りで入力してください">
+        <div class="mb-4 relative">
+            <label for="tags-input" class="block text-gray-700 font-bold mb-2">タグ</label>
+            <x-tag-input name="tags" :value="old('tags', $tagNames)" placeholder="タグを入力してください（Enterで追加）" />
             <div class="text-sm text-gray-500 mt-1">各タグは50文字以内、最大20個まで。文字、数字、アンダースコア、ハイフンが使用可能。</div>
             @error('tags')
                 <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
@@ -48,14 +48,8 @@
     </form>
 
     <script>
-        // タイトルとタグのinputでエンターキー押下時のフォーム送信を阻止
+        // タイトルのinputでエンターキー押下時のフォーム送信を阻止
         document.getElementById('title').addEventListener('keydown', function(e) {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-            }
-        });
-
-        document.getElementById('tags').addEventListener('keydown', function(e) {
             if (e.key === 'Enter') {
                 e.preventDefault();
             }


### PR DESCRIPTION
## Summary
- 記事作成・編集時のタグ入力を検索画面と同じインタラクティブなUIに統一
- 再利用可能なタグコンポーネントを作成し、一貫したタグ操作体験を提供
- 自動補完機能、タグチップ表示、IME対応を実装

## Changes
- `components/tag-input.blade.php`: 新規作成 - 再利用可能なタグ入力コンポーネント
- `notes/create.blade.php`: タグ入力UIを新しいコンポーネントに置き換え
- `notes/edit.blade.php`: 同様にタグ入力UIを改善
- `home.blade.php`: 入力欄のクリア処理を改善（IME対応）

## Features implemented
- ✅ インタラクティブなタグチップ表示（個別削除可能）
- ✅ リアルタイムタグ候補表示（既存の/tagsエンドポイント活用）
- ✅ 重複タグの防止機能
- ✅ タグ結合機能（::オペレーター）対応
- ✅ IME入力対応とフォーカス管理
- ✅ 検索画面との操作体験統一

## Test plan
- [ ] 記事作成画面でタグが正しく追加・削除できることを確認
- [ ] 記事編集画面で既存タグが正しく表示・編集できることを確認
- [ ] タグの自動補完機能が動作することを確認
- [ ] エンターキー押下後に入力欄がクリアされることを確認
- [ ] 日本語入力でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)