### PR TITLE
[Issue #10] ノートの履歴管理機能

### DIFF
--- a/private-wiki/app/Models/Note.php
+++ b/private-wiki/app/Models/Note.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Note extends Model
 {
@@ -11,8 +12,63 @@ class Note extends Model
 
     protected $fillable = ['title', 'body'];
 
+    protected static function booted()
+    {
+        static::created(function ($note) {
+            $note->createHistory('created');
+        });
+
+        static::updated(function ($note) {
+            $note->createHistory('updated');
+        });
+
+        static::deleted(function ($note) {
+            $note->createHistory('deleted');
+        });
+    }
+
     public function tags()
     {
         return $this->belongsToMany(Tag::class);
+    }
+
+    public function histories(): HasMany
+    {
+        return $this->hasMany(NoteHistory::class)->orderBy('version', 'desc');
+    }
+
+    public function createHistory(string $changeType): void
+    {
+        $lastVersion = $this->histories()->max('version') ?? 0;
+        
+        NoteHistory::create([
+            'note_id' => $this->id,
+            'title' => $this->title,
+            'body' => $this->body,
+            'tags_snapshot' => $this->tags->pluck('name')->toArray(),
+            'change_type' => $changeType,
+            'version' => $lastVersion + 1,
+        ]);
+    }
+
+    public function restoreVersion(int $version): bool
+    {
+        $history = $this->histories()->where('version', $version)->first();
+        
+        if (!$history) {
+            return false;
+        }
+
+        $this->update([
+            'title' => $history->title,
+            'body' => $history->body,
+        ]);
+
+        if ($history->tags_snapshot) {
+            $tags = Tag::whereIn('name', $history->tags_snapshot)->get();
+            $this->tags()->sync($tags->pluck('id'));
+        }
+
+        return true;
     }
 }

--- a/private-wiki/app/Models/NoteHistory.php
+++ b/private-wiki/app/Models/NoteHistory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NoteHistory extends Model
+{
+    protected $fillable = [
+        'note_id',
+        'title',
+        'body',
+        'tags_snapshot',
+        'change_type',
+        'version',
+    ];
+
+    protected $casts = [
+        'tags_snapshot' => 'array',
+    ];
+
+    public function note(): BelongsTo
+    {
+        return $this->belongsTo(Note::class);
+    }
+}

--- a/private-wiki/database/migrations/2025_08_21_084911_create_note_histories_table.php
+++ b/private-wiki/database/migrations/2025_08_21_084911_create_note_histories_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('note_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('note_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->longText('body');
+            $table->json('tags_snapshot')->nullable();
+            $table->enum('change_type', ['created', 'updated', 'deleted'])->default('updated');
+            $table->integer('version')->default(1);
+            $table->timestamps();
+            
+            $table->index(['note_id', 'version']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('note_histories');
+    }
+};

--- a/private-wiki/public/css/app.css
+++ b/private-wiki/public/css/app.css
@@ -1258,6 +1258,10 @@ video {
   margin-top: auto;
 }
 
+.mr-1 {
+  margin-right: 0.25rem;
+}
+
 .block {
   display: block;
 }
@@ -1316,6 +1320,10 @@ video {
 
 .max-h-40 {
   max-height: 10rem;
+}
+
+.max-h-32 {
+  max-height: 8rem;
 }
 
 .min-h-screen {
@@ -1490,6 +1498,12 @@ video {
   margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
 }
 
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
 .overflow-y-auto {
   overflow-y: auto;
 }
@@ -1581,6 +1595,21 @@ video {
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
 }
 
+.border-blue-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(191 219 254 / var(--tw-border-opacity, 1));
+}
+
+.border-green-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(187 247 208 / var(--tw-border-opacity, 1));
+}
+
+.border-red-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
+}
+
 .bg-blue-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(219 234 254 / var(--tw-bg-opacity, 1));
@@ -1648,6 +1677,21 @@ video {
 
 .bg-transparent {
   background-color: transparent;
+}
+
+.bg-blue-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+}
+
+.bg-gray-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+
+.bg-green-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(34 197 94 / var(--tw-bg-opacity, 1));
 }
 
 .bg-opacity-50 {
@@ -2032,6 +2076,16 @@ video {
 .hover\:bg-yellow-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(202 138 4 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-blue-600:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-green-600:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:text-gray-400:hover {

--- a/private-wiki/resources/views/notes.blade.php
+++ b/private-wiki/resources/views/notes.blade.php
@@ -22,6 +22,7 @@
     
     <div class="mt-4 flex gap-2">
         <a href="{{ route('notes.edit', $note->id) }}" class="bg-yellow-500 text-white px-4 py-2 rounded hover:bg-yellow-600 transition-colors duration-200">編集</a>
+        <a href="{{ route('notes.history', $note->id) }}" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition-colors duration-200">履歴</a>
         
         <div x-data="{ showConfirm: false }">
             <button @click="showConfirm = true" class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 transition-colors duration-200">削除</button>

--- a/private-wiki/resources/views/notes/history.blade.php
+++ b/private-wiki/resources/views/notes/history.blade.php
@@ -1,0 +1,76 @@
+@extends('layouts.app')
+
+@section('title', 'ノート履歴')
+
+@section('content')
+    <h1 class="text-2xl font-bold mb-4">「{{ $note->title }}」の履歴</h1>
+    
+    <div class="mb-4">
+        <a href="{{ route('notes.show', $note->id) }}" class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 transition-colors duration-200">ノートに戻る</a>
+    </div>
+
+    @if($histories->count() > 0)
+        <div class="space-y-4">
+            @foreach($histories as $history)
+                <div class="bg-white p-4 rounded shadow border {{ $history->change_type === 'created' ? 'border-green-200' : ($history->change_type === 'deleted' ? 'border-red-200' : 'border-blue-200') }}">
+                    <div class="flex justify-between items-center mb-2">
+                        <div class="flex items-center gap-2">
+                            <span class="text-sm font-semibold">バージョン {{ $history->version }}</span>
+                            <span class="inline-block px-2 py-1 text-xs rounded {{ $history->change_type === 'created' ? 'bg-green-100 text-green-700' : ($history->change_type === 'deleted' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700') }}">
+                                {{ $history->change_type === 'created' ? '作成' : ($history->change_type === 'deleted' ? '削除' : '更新') }}
+                            </span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <span class="text-gray-500 text-xs">{{ \Carbon\Carbon::parse($history->created_at)->format('Y/m/d H:i') }}</span>
+                            @if($history->change_type !== 'deleted')
+                                <form action="{{ route('notes.restore', [$note->id, $history->version]) }}" method="POST" class="inline">
+                                    @csrf
+                                    <button type="submit" class="bg-green-500 text-white px-3 py-1 text-xs rounded hover:bg-green-600 transition-colors duration-200" onclick="return confirm('バージョン {{ $history->version }} に復元しますか？')">復元</button>
+                                </form>
+                            @endif
+                        </div>
+                    </div>
+                    
+                    <div class="text-sm text-gray-700 mb-2">
+                        <strong>タイトル:</strong> {{ $history->title }}
+                    </div>
+                    
+                    @if($history->tags_snapshot && count($history->tags_snapshot) > 0)
+                        <div class="mb-2">
+                            <span class="text-sm text-gray-600">タグ: </span>
+                            @foreach($history->tags_snapshot as $tag)
+                                <span class="inline-block bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded mr-1">{{ $tag }}</span>
+                            @endforeach
+                        </div>
+                    @endif
+                    
+                    <div class="text-sm">
+                        <strong class="text-gray-600">内容:</strong>
+                        <div class="mt-1 p-2 bg-gray-50 rounded text-xs max-h-32 overflow-y-auto">
+                            {{ Str::limit($history->body, 200) }}
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+        <div class="mt-6">
+            @if($histories->hasPages())
+                <div class="text-center mb-4">
+                    <span class="text-sm text-gray-600">
+                        ページ {{ $histories->currentPage() }} / {{ $histories->lastPage() }} 
+                        （全 {{ $histories->total() }} 件中 {{ $histories->firstItem() }}-{{ $histories->lastItem() }} 件を表示）
+                    </span>
+                </div>
+            @endif
+            
+            <div class="flex justify-center">
+                {{ $histories->links() }}
+            </div>
+        </div>
+    @else
+        <div class="bg-gray-100 p-4 rounded text-center text-gray-600">
+            履歴がありません。
+        </div>
+    @endif
+@endsection

--- a/private-wiki/routes/web.php
+++ b/private-wiki/routes/web.php
@@ -19,6 +19,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/notes/{id}/edit', [NoteController::class, 'edit'])->name('notes.edit');
     Route::put('/notes/{id}', [NoteController::class, 'update'])->name('notes.update');
     Route::delete('/notes/{id}', [NoteController::class, 'destroy'])->name('notes.destroy');
+    Route::get('/notes/{id}/history', [NoteController::class, 'history'])->name('notes.history');
+    Route::post('/notes/{id}/restore/{version}', [NoteController::class, 'restore'])->name('notes.restore');
     
     // タグ候補API
     Route::get('/tags', [TagController::class, 'index']);


### PR DESCRIPTION
## Summary
- ノートの作成・更新・削除時に自動で履歴を記録する機能を実装
- バージョン管理システムを追加し、過去のバージョンに復元可能
- タグの状態もスナップショットとして保存
- 履歴表示画面と復元機能を提供

## Test plan
- [x] マイグレーションの実行確認
- [x] ノート作成時の履歴記録
- [x] ノート更新時の履歴記録  
- [x] 履歴表示画面の動作
- [x] バージョン復元機能
- [x] 既存テストの通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #10