### PR TITLE
[Issue #16] 1ページに表示するノート数を30件に変更

### DIFF
--- a/private-wiki/app/Http/Controllers/NoteController.php
+++ b/private-wiki/app/Http/Controllers/NoteController.php
@@ -44,7 +44,7 @@ class NoteController extends Controller
             });
         }
 
-        $notes = $query->orderBy('updated_at', 'desc')->paginate(10)->appends($request->all());
+        $notes = $query->orderBy('updated_at', 'desc')->paginate(30)->appends($request->all());
 
         return view('home', compact('notes'));
     }
@@ -227,7 +227,7 @@ class NoteController extends Controller
             return redirect('/')->with('error', '指定されたノートが見つかりません。');
         }
 
-        $histories = $note->histories()->with('note')->paginate(10);
+        $histories = $note->histories()->with('note')->paginate(30);
 
         return view('notes.history', compact('note', 'histories'));
     }


### PR DESCRIPTION
## 変更概要
ノート一覧とノート履歴のページネーション表示件数を10件から30件に変更しました。

## 変更内容
- `NoteController.php:47` - メインのノート一覧ページのページネーション件数を変更
- `NoteController.php:230` - ノート履歴ページのページネーション件数を変更

## テスト
- PHPUnit テスト全て通過確認済み

Closes #16