### PR TITLE
[Issue #17] タグ検索の近くに、タグの特殊操作の説明の記述を入れる

### DIFF
--- a/private-wiki/public/css/app.css
+++ b/private-wiki/public/css/app.css
@@ -1262,6 +1262,10 @@ video {
   margin-right: 0.25rem;
 }
 
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
 .block {
   display: block;
 }
@@ -1440,6 +1444,10 @@ video {
   flex-wrap: wrap;
 }
 
+.items-start {
+  align-items: flex-start;
+}
+
 .items-center {
   align-items: center;
 }
@@ -1502,6 +1510,10 @@ video {
   --tw-space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.self-start {
+  align-self: flex-start;
 }
 
 .overflow-y-auto {
@@ -1903,6 +1915,10 @@ video {
   color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
 
+.underline {
+  text-decoration-line: underline;
+}
+
 .placeholder-gray-400::-moz-placeholder {
   --tw-placeholder-opacity: 1;
   color: rgb(156 163 175 / var(--tw-placeholder-opacity, 1));
@@ -2128,6 +2144,11 @@ video {
   color: rgb(252 165 165 / var(--tw-text-opacity, 1));
 }
 
+.hover\:text-blue-800:hover {
+  --tw-text-opacity: 1;
+  color: rgb(30 64 175 / var(--tw-text-opacity, 1));
+}
+
 .focus\:z-10:focus {
   z-index: 10;
 }
@@ -2227,6 +2248,10 @@ video {
 }
 
 @media (min-width: 768px) {
+  .md\:mt-0 {
+    margin-top: 0px;
+  }
+
   .md\:w-1\/3 {
     width: 33.333333%;
   }

--- a/private-wiki/resources/views/home.blade.php
+++ b/private-wiki/resources/views/home.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'ホーム')
 
 @section('content')
-    <form method="GET" action="/" class="mb-8 flex flex-col md:flex-row gap-4 items-center" id="search-form">
+    <form method="GET" action="/" class="mb-8 flex flex-col md:flex-row gap-4 items-start" id="search-form">
         <input
             type="text"
             name="title"
@@ -26,10 +26,20 @@
             </div>
             <ul id="tag-suggestions" class="absolute bg-white border w-full z-10 hidden"></ul>
             <input type="hidden" name="tag" id="tag-hidden">
+            <div class="mt-1 text-xs text-gray-500">
+                <button type="button" id="tag-help-toggle" class="text-blue-600 hover:text-blue-800 underline">
+                    タグ検索のヒント
+                </button>
+                <div id="tag-help-content" class="hidden mt-2 p-2 bg-gray-50 rounded text-xs">
+                    <div class="mb-1"><strong>OR検索:</strong> <code>tag1,tag2</code> → いずれかのタグを持つ記事</div>
+                    <div class="mb-1"><strong>AND検索:</strong> <code>tag1::tag2</code> → 両方のタグを持つ記事</div>
+                    <div><strong>複合検索:</strong> <code>tag1::tag2,tag3</code> → (tag1とtag2を両方持つ) または (tag3を持つ) 記事</div>
+                </div>
+            </div>
         </div>
         <button
             type="submit"
-            class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+            class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition self-start md:mt-0"
         >
             検索
         </button>
@@ -197,6 +207,20 @@
 
                 tagSuggestions.classList.toggle('hidden', !hasSuggestions);
             });
+    });
+
+    // ヒント表示の切り替え
+    document.getElementById('tag-help-toggle').addEventListener('click', function() {
+        const helpContent = document.getElementById('tag-help-content');
+        const isHidden = helpContent.classList.contains('hidden');
+        
+        if (isHidden) {
+            helpContent.classList.remove('hidden');
+            this.textContent = 'ヒントを非表示';
+        } else {
+            helpContent.classList.add('hidden');
+            this.textContent = 'タグ検索のヒント';
+        }
     });
 
     // 初期値読み込み


### PR DESCRIPTION
## Summary
- タグ検索欄の下に「タグ検索のヒント」ボタンを追加
- クリックでOR検索、AND検索、複合検索の使用方法を表示/非表示切り替え
- フォームレイアウトを調整してUIの整合性を保持

## Test plan
- [x] タグ検索のヒントボタンが正しく表示される
- [x] クリックで説明が表示/非表示される  
- [x] 説明内容が正確に表示される
- [x] レイアウトが整合性を保っている
- [x] 既存のテストがパスする

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #17