### PR TITLE
[Issue #2] 記事作成時のMarkdown変換を１行ごとに行う

### DIFF
--- a/private-wiki/app/Http/Controllers/NoteController.php
+++ b/private-wiki/app/Http/Controllers/NoteController.php
@@ -57,8 +57,11 @@ class NoteController extends Controller
             return redirect('/')->with('error', '指定されたノートが見つかりません。');
         }
 
-        $converter = new CommonMarkConverter;
-        $note->body = $converter->convertToHtml($note->body);
+        // 手動で改行を2つの改行（段落区切り）に変換してからMarkdownを処理
+        $bodyWithBreaks = str_replace("\n", "\n\n", $note->body);
+        
+        $converter = new CommonMarkConverter();
+        $note->body = $converter->convertToHtml($bodyWithBreaks);
 
         return view('notes', compact('note'));
     }
@@ -245,5 +248,17 @@ class NoteController extends Controller
         } else {
             return redirect()->route('notes.history', $note->id)->with('error', '指定されたバージョンが見つかりません。');
         }
+    }
+
+    public function convertMarkdown(Request $request)
+    {
+        $request->validate([
+            'markdown' => 'required|string|max:1000'
+        ]);
+
+        $converter = new CommonMarkConverter();
+        $html = $converter->convert($request->markdown)->getContent();
+
+        return response()->json(['html' => $html]);
     }
 }

--- a/private-wiki/public/css/app.css
+++ b/private-wiki/public/css/app.css
@@ -1132,6 +1132,10 @@ video {
   --tw-prose-invert-td-borders: oklch(37.2% 0.044 257.287);
 }
 
+.collapse {
+  visibility: collapse;
+}
+
 .fixed {
   position: fixed;
 }
@@ -1184,6 +1188,11 @@ video {
 .mx-4 {
   margin-left: 1rem;
   margin-right: 1rem;
+}
+
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .mb-2 {
@@ -1336,6 +1345,10 @@ video {
 
 .min-h-\[2\.5rem\] {
   min-height: 2.5rem;
+}
+
+.min-h-\[240px\] {
+  min-height: 240px;
 }
 
 .w-16 {
@@ -1552,6 +1565,11 @@ video {
   border-bottom-right-radius: 0.375rem;
 }
 
+.rounded-t {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
 .border {
   border-width: 1px;
 }
@@ -1562,6 +1580,10 @@ video {
 
 .border-t {
   border-top-width: 1px;
+}
+
+.border-l-4 {
+  border-left-width: 4px;
 }
 
 .border-none {
@@ -1620,6 +1642,11 @@ video {
 .border-red-200 {
   --tw-border-opacity: 1;
   border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
+}
+
+.border-gray-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(75 85 99 / var(--tw-border-opacity, 1));
 }
 
 .bg-blue-100 {
@@ -1706,6 +1733,11 @@ video {
   background-color: rgb(34 197 94 / var(--tw-bg-opacity, 1));
 }
 
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
+}
+
 .bg-opacity-50 {
   --tw-bg-opacity: 0.5;
 }
@@ -1771,12 +1803,25 @@ video {
   padding-right: 0.75rem;
 }
 
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
 .pt-4 {
   padding-top: 1rem;
 }
 
+.pl-4 {
+  padding-left: 1rem;
+}
+
 .text-center {
   text-align: center;
+}
+
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .text-2xl {
@@ -1809,6 +1854,11 @@ video {
   line-height: 1.75rem;
 }
 
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
 .font-bold {
   font-weight: 700;
 }
@@ -1819,6 +1869,10 @@ video {
 
 .font-medium {
   font-weight: 500;
+}
+
+.italic {
+  font-style: italic;
 }
 
 .leading-5 {
@@ -1915,8 +1969,22 @@ video {
   color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
 
+.text-green-400 {
+  --tw-text-opacity: 1;
+  color: rgb(74 222 128 / var(--tw-text-opacity, 1));
+}
+
+.text-blue-400 {
+  --tw-text-opacity: 1;
+  color: rgb(96 165 250 / var(--tw-text-opacity, 1));
+}
+
 .underline {
   text-decoration-line: underline;
+}
+
+.line-through {
+  text-decoration-line: line-through;
 }
 
 .placeholder-gray-400::-moz-placeholder {
@@ -1978,6 +2046,10 @@ video {
 .outline-none {
   outline: 2px solid transparent;
   outline-offset: 2px;
+}
+
+.outline {
+  outline-style: solid;
 }
 
 .ring-gray-300 {

--- a/private-wiki/resources/views/layouts/app.blade.php
+++ b/private-wiki/resources/views/layouts/app.blade.php
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>@yield('title', 'My Wiki')</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/private-wiki/resources/views/notes/create.blade.php
+++ b/private-wiki/resources/views/notes/create.blade.php
@@ -31,9 +31,14 @@
 
         {{-- ボディ入力 --}}
         <div class="mb-4">
-            <label for="body" class="block text-gray-700 font-bold mb-2">内容<span class="text-red-500 ml-1">*</span></label>
-            <textarea name="body" id="body" rows="10" maxlength="65535" class="w-full border-gray-300 rounded px-4 py-2 @error('body') border-red-500 @enderror" placeholder="内容を入力してください（Markdown記法が使用できます）" required>{{ old('body') }}</textarea>
-            <div class="text-sm text-gray-500 mt-1">最大65535文字。Markdown記法が使用できます。</div>
+            <label for="body-editor" class="block text-gray-700 font-bold mb-2">内容<span class="text-red-500 ml-1">*</span></label>
+            <div id="body-editor" 
+                 contenteditable="true" 
+                 class="w-full border-gray-300 rounded px-4 py-2 min-h-[240px] border focus:ring-2 focus:ring-blue-500 focus:border-blue-500 @error('body') border-red-500 @enderror" 
+                 data-placeholder="内容を入力してください（Markdown記法が使用できます）"
+                 style="white-space: pre-wrap;">{{ old('body') }}</div>
+            <textarea name="body" id="body" class="hidden" required>{{ old('body') }}</textarea>
+            <div class="text-sm text-gray-500 mt-1">最大65535文字。Markdown記法が使用できます。行ごとにリアルタイムプレビューされます。</div>
             @error('body')
                 <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
             @enderror
@@ -50,5 +55,409 @@
                 e.preventDefault();
             }
         });
+
+        // Markdownエディター機能
+        class MarkdownEditor {
+            constructor() {
+                this.editor = document.getElementById('body-editor');
+                this.hiddenInput = document.getElementById('body');
+                this.lines = new Map(); // 行データを管理
+                this.currentLineElement = null;
+                this.isConverting = false;
+                this.init();
+            }
+
+            init() {
+                this.editor.addEventListener('keydown', this.handleKeydown.bind(this));
+                this.editor.addEventListener('keyup', this.handleKeyup.bind(this));
+                this.editor.addEventListener('input', this.handleInput.bind(this));
+                this.editor.addEventListener('click', this.handleClick.bind(this));
+                
+                // プレースホルダー表示
+                this.updatePlaceholder();
+                
+                // フォーム送信前にhidden inputを更新
+                document.querySelector('form').addEventListener('submit', (e) => {
+                    this.convertAllLinesToMarkdown();
+                });
+
+                // 初期化時に最初の行を作成
+                this.ensureLineStructure();
+                
+                console.log('Markdown editor initialized');
+            }
+
+            handleKeydown(e) {
+                console.log('Key pressed:', e.key);
+                
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    
+                    // 現在の行をHTML変換してから新しい行を作成
+                    const currentLine = this.getCurrentLine();
+                    if (currentLine) {
+                        this.convertLineToHTML(currentLine);
+                    }
+                    
+                    // 新しい行を作成
+                    this.createNewLine();
+                }
+            }
+
+            handleKeyup(e) {
+                // 矢印キーでの行移動を検出
+                if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+                    this.checkLineChange();
+                }
+            }
+
+            handleInput(e) {
+                this.updatePlaceholder();
+                
+                // 現在の行のdata-markdown属性を更新
+                const currentLine = this.getCurrentLine();
+                if (currentLine) {
+                    const currentText = currentLine.textContent || '';
+                    currentLine.setAttribute('data-markdown', currentText);
+                }
+                
+                this.updateHiddenInput();
+            }
+
+            handleClick(e) {
+                // 前の行をHTML変換
+                if (this.currentLineElement) {
+                    this.convertLineToHTML(this.currentLineElement);
+                }
+                
+                // クリックした行をMarkdown表示に戻す
+                const clickedLine = this.getLineFromEvent(e);
+                if (clickedLine) {
+                    this.convertLineToMarkdown(clickedLine);
+                    this.currentLineElement = clickedLine;
+                    
+                    // クリック後にカーソルを最後尾に設定
+                    setTimeout(() => {
+                        this.setCursorToEnd(clickedLine);
+                    }, 10);
+                    
+                    console.log('Clicked line converted to Markdown');
+                }
+            }
+
+            checkLineChange() {
+                const newLine = this.getCurrentLine();
+                if (newLine && newLine !== this.currentLineElement) {
+                    // 前の行をHTML変換
+                    if (this.currentLineElement) {
+                        this.convertLineToHTML(this.currentLineElement);
+                        console.log('Line changed, converting previous line to HTML');
+                    }
+                    
+                    // 新しい行をMarkdown表示に戻す
+                    this.convertLineToMarkdown(newLine);
+                    this.currentLineElement = newLine;
+                    
+                    // カーソルを最後尾に設定
+                    setTimeout(() => {
+                        this.setCursorToEnd(newLine);
+                    }, 10);
+                    
+                    console.log('New line set to Markdown mode');
+                }
+            }
+
+            setCursorToEnd(element) {
+                const range = document.createRange();
+                const sel = window.getSelection();
+                
+                // 要素の最後尾にカーソルを設定
+                if (element.childNodes.length > 0) {
+                    const lastChild = element.childNodes[element.childNodes.length - 1];
+                    if (lastChild.nodeType === Node.TEXT_NODE) {
+                        range.setStart(lastChild, lastChild.textContent.length);
+                    } else {
+                        range.setStart(element, element.childNodes.length);
+                    }
+                } else {
+                    range.setStart(element, 0);
+                }
+                range.collapse(true);
+                
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
+
+            getCurrentLine() {
+                const selection = window.getSelection();
+                if (selection.rangeCount === 0) return null;
+                
+                let node = selection.getRangeAt(0).startContainer;
+                
+                // テキストノードの場合、親要素を取得
+                if (node.nodeType === Node.TEXT_NODE) {
+                    node = node.parentNode;
+                }
+                
+                // 現在の行を見つける
+                while (node && node !== this.editor) {
+                    if (node.classList && node.classList.contains('editor-line')) {
+                        return node;
+                    }
+                    node = node.parentNode;
+                }
+                return null;
+            }
+
+            getLineFromEvent(e) {
+                let target = e.target;
+                while (target && target !== this.editor) {
+                    if (target.classList && target.classList.contains('editor-line')) {
+                        return target;
+                    }
+                    target = target.parentNode;
+                }
+                return null;
+            }
+
+            ensureLineStructure() {
+                if (this.editor.children.length === 0) {
+                    const firstLine = document.createElement('div');
+                    firstLine.classList.add('editor-line');
+                    firstLine.setAttribute('contenteditable', 'true');
+                    firstLine.setAttribute('data-markdown', ''); // 空の原文で初期化
+                    this.editor.appendChild(firstLine);
+                    firstLine.focus();
+                }
+            }
+
+
+            createNewLine() {
+                const newLine = document.createElement('div');
+                newLine.classList.add('editor-line');
+                newLine.setAttribute('contenteditable', 'true');
+                newLine.setAttribute('data-markdown', ''); // 空の原文で初期化
+                
+                // カーソル位置の後に挿入
+                const selection = window.getSelection();
+                if (selection.rangeCount > 0) {
+                    const range = selection.getRangeAt(0);
+                    let currentLine = range.startContainer;
+                    
+                    if (currentLine.nodeType === Node.TEXT_NODE) {
+                        currentLine = currentLine.parentNode;
+                    }
+                    
+                    while (currentLine && !currentLine.classList.contains('editor-line')) {
+                        currentLine = currentLine.parentNode;
+                    }
+                    
+                    if (currentLine) {
+                        currentLine.parentNode.insertBefore(newLine, currentLine.nextSibling);
+                    } else {
+                        this.editor.appendChild(newLine);
+                    }
+                } else {
+                    this.editor.appendChild(newLine);
+                }
+                
+                // 新しい行にカーソルを設定（最後尾に）
+                setTimeout(() => {
+                    const range = document.createRange();
+                    const sel = window.getSelection();
+                    
+                    // 行の最後尾にカーソルを設定
+                    if (newLine.childNodes.length > 0) {
+                        const lastChild = newLine.childNodes[newLine.childNodes.length - 1];
+                        if (lastChild.nodeType === Node.TEXT_NODE) {
+                            range.setStart(lastChild, lastChild.textContent.length);
+                        } else {
+                            range.setStart(newLine, newLine.childNodes.length);
+                        }
+                    } else {
+                        range.setStart(newLine, 0);
+                    }
+                    range.collapse(true);
+                    
+                    sel.removeAllRanges();
+                    sel.addRange(range);
+                    
+                    newLine.focus();
+                    this.currentLineElement = newLine;
+                    
+                    console.log('New line created and focused at end');
+                }, 10);
+            }
+
+            async convertLineToHTML(lineElement) {
+                if (this.isConverting || !lineElement) return;
+                
+                const markdown = lineElement.textContent.trim();
+                if (!markdown) return;
+                
+                console.log('Converting to HTML:', markdown);
+                
+                try {
+                    this.isConverting = true;
+                    
+                    // Markdownの原文を保存
+                    lineElement.setAttribute('data-markdown', markdown);
+                    
+                    // コードブロック内かどうかチェック
+                    if (this.isLineInCodeBlock(lineElement)) {
+                        // コードブロック内の行は変換しない
+                        console.log('Line is in code block, skipping conversion');
+                        return;
+                    }
+                    
+                    // 通常のHTML変換を実行
+                    const html = this.simpleMarkdownToHTML(markdown);
+                    if (html !== markdown) {
+                        lineElement.innerHTML = html;
+                        lineElement.classList.add('markdown-rendered');
+                        console.log('Line converted to HTML');
+                    }
+                    
+                } catch (error) {
+                    console.error('Markdown conversion error:', error);
+                } finally {
+                    this.isConverting = false;
+                }
+            }
+
+            isLineInCodeBlock(lineElement) {
+                // 現在の行がコードブロック内かどうかを判定
+                const lines = this.editor.querySelectorAll('.editor-line');
+                let inCodeBlock = false;
+                
+                for (let line of lines) {
+                    const text = line.getAttribute('data-markdown') || line.textContent.trim();
+                    
+                    if (text.startsWith('```')) {
+                        if (line === lineElement) {
+                            // 現在の行が```の行の場合は変換しない
+                            return true;
+                        }
+                        inCodeBlock = !inCodeBlock;
+                    } else if (line === lineElement) {
+                        return inCodeBlock;
+                    }
+                }
+                
+                return false;
+            }
+
+
+            simpleMarkdownToHTML(markdown) {
+                return markdown
+                    // 見出し（最初に処理）
+                    .replace(/^#### (.*$)/gm, '<span class="text-base font-bold">$1</span>')
+                    .replace(/^### (.*$)/gm, '<span class="text-lg font-bold">$1</span>')
+                    .replace(/^## (.*$)/gm, '<span class="text-xl font-bold">$1</span>')
+                    .replace(/^# (.*$)/gm, '<span class="text-2xl font-bold">$1</span>')
+                    
+                    // 引用
+                    .replace(/^> (.*$)/gm, '<div class="border-l-4 border-gray-300 pl-4 italic text-gray-600">$1</div>')
+                    
+                    // 水平線
+                    .replace(/^---$/gm, '<hr class="border-gray-300 my-2">')
+                    .replace(/^\*\*\*$/gm, '<hr class="border-gray-300 my-2">')
+                    
+                    // リスト
+                    .replace(/^- (.*$)/gm, '<span class="flex items-start"><span class="mr-2">•</span><span>$1</span></span>')
+                    .replace(/^\* (.*$)/gm, '<span class="flex items-start"><span class="mr-2">•</span><span>$1</span></span>')
+                    .replace(/^\+ (.*$)/gm, '<span class="flex items-start"><span class="mr-2">•</span><span>$1</span></span>')
+                    .replace(/^(\d+)\. (.*$)/gm, '<span class="flex items-start"><span class="mr-2">$1.</span><span>$2</span></span>')
+                    
+                    // チェックボックス
+                    .replace(/^- \[ \] (.*$)/gm, '<span class="flex items-start"><span class="mr-2">☐</span><span>$1</span></span>')
+                    .replace(/^- \[x\] (.*$)/gm, '<span class="flex items-start"><span class="mr-2">☑</span><span class="line-through">$1</span></span>')
+                    
+                    // インライン要素（最後に処理）
+                    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+                    .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                    .replace(/`(.*?)`/g, '<code class="bg-gray-200 px-1 rounded">$1</code>')
+                    .replace(/~~(.*?)~~/g, '<span class="line-through">$1</span>')
+                    
+                    // リンク
+                    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-blue-600 underline">$1</a>');
+            }
+
+            convertLineToMarkdown(lineElement) {
+                if (lineElement && lineElement.classList.contains('markdown-rendered')) {
+                    const markdown = lineElement.getAttribute('data-markdown');
+                    if (markdown) {
+                        lineElement.textContent = markdown;
+                        // data-markdown属性も更新（textContentと一致させる）
+                        lineElement.setAttribute('data-markdown', markdown);
+                        lineElement.classList.remove('markdown-rendered');
+                        console.log('Line converted back to Markdown');
+                    }
+                } else if (lineElement) {
+                    // HTML変換されていない行も、data-markdown属性を現在のtextContentで更新
+                    const currentText = lineElement.textContent || '';
+                    lineElement.setAttribute('data-markdown', currentText);
+                }
+            }
+
+            convertAllLinesToMarkdown() {
+                const lines = this.editor.querySelectorAll('.editor-line');
+                lines.forEach(line => {
+                    this.convertLineToMarkdown(line);
+                });
+                this.updateHiddenInput();
+            }
+
+            updateHiddenInput() {
+                const lines = this.editor.querySelectorAll('.editor-line');
+                const contentLines = Array.from(lines).map(line => {
+                    // data-markdown属性がある場合は原文を使用、なければtextContentを使用
+                    const markdown = line.getAttribute('data-markdown');
+                    const text = markdown || line.textContent || '';
+                    // 空行も含めて保持する
+                    return text;
+                });
+                
+                // 最後の空行を除去しない（すべての行を保持）
+                const content = contentLines.join('\n');
+                this.hiddenInput.value = content;
+                console.log('Hidden input updated lines:', contentLines);
+                console.log('Hidden input final content:', content);
+            }
+
+            updatePlaceholder() {
+                const isEmpty = !this.editor.textContent.trim();
+                if (isEmpty) {
+                    this.editor.classList.add('empty');
+                } else {
+                    this.editor.classList.remove('empty');
+                }
+            }
+        }
+
+        // エディターを初期化
+        new MarkdownEditor();
     </script>
+
+    <style>
+        #body-editor.empty:before {
+            content: attr(data-placeholder);
+            color: #9ca3af;
+            pointer-events: none;
+        }
+        
+        .editor-line {
+            min-height: 1.5em;
+            margin: 2px 0;
+            outline: none;
+        }
+        
+        .editor-line.markdown-rendered {
+            /* 変換された行のスタイルを削除 - 通常のテキストと同じ見た目に */
+        }
+        
+        #body-editor:focus {
+            outline: none;
+        }
+    </style>
 @endsection

--- a/private-wiki/resources/views/notes/edit.blade.php
+++ b/private-wiki/resources/views/notes/edit.blade.php
@@ -32,9 +32,14 @@
 
         {{-- ボディ入力 --}}
         <div class="mb-4">
-            <label for="body" class="block text-gray-700 font-bold mb-2">内容<span class="text-red-500 ml-1">*</span></label>
-            <textarea name="body" id="body" rows="10" maxlength="65535" class="w-full border-gray-300 rounded px-4 py-2 @error('body') border-red-500 @enderror" placeholder="内容を入力してください（Markdown記法が使用できます）" required>{{ old('body', $note->body) }}</textarea>
-            <div class="text-sm text-gray-500 mt-1">最大65535文字。Markdown記法が使用できます。</div>
+            <label for="body-editor" class="block text-gray-700 font-bold mb-2">内容<span class="text-red-500 ml-1">*</span></label>
+            <div id="body-editor" 
+                 contenteditable="true" 
+                 class="w-full border-gray-300 rounded px-4 py-2 min-h-[240px] border focus:ring-2 focus:ring-blue-500 focus:border-blue-500 @error('body') border-red-500 @enderror" 
+                 data-placeholder="内容を入力してください（Markdown記法が使用できます）"
+                 style="white-space: pre-wrap;">{{ old('body', $note->body) }}</div>
+            <textarea name="body" id="body" class="hidden" required>{{ old('body', $note->body) }}</textarea>
+            <div class="text-sm text-gray-500 mt-1">最大65535文字。Markdown記法が使用できます。行ごとにリアルタイムプレビューされます。</div>
             @error('body')
                 <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
             @enderror
@@ -54,5 +59,433 @@
                 e.preventDefault();
             }
         });
+
+        // Markdownエディター機能
+        class MarkdownEditor {
+            constructor() {
+                this.editor = document.getElementById('body-editor');
+                this.hiddenInput = document.getElementById('body');
+                this.lines = new Map(); // 行データを管理
+                this.currentLineElement = null;
+                this.isConverting = false;
+                this.init();
+            }
+
+            init() {
+                this.editor.addEventListener('keydown', this.handleKeydown.bind(this));
+                this.editor.addEventListener('keyup', this.handleKeyup.bind(this));
+                this.editor.addEventListener('input', this.handleInput.bind(this));
+                this.editor.addEventListener('click', this.handleClick.bind(this));
+                
+                // プレースホルダー表示
+                this.updatePlaceholder();
+                
+                // フォーム送信前にhidden inputを更新
+                document.querySelector('form').addEventListener('submit', (e) => {
+                    this.convertAllLinesToMarkdown();
+                });
+
+                // 初期化時に既存のテキストを行構造に変換
+                this.initializeFromExistingText();
+                
+                console.log('Markdown editor initialized');
+            }
+
+            initializeFromExistingText() {
+                const existingText = this.editor.textContent.trim();
+                if (existingText) {
+                    // 既存のテキストを行ごとに分割してdiv要素に変換
+                    const lines = existingText.split('\n');
+                    this.editor.innerHTML = '';
+                    
+                    lines.forEach((lineText, index) => {
+                        const lineDiv = document.createElement('div');
+                        lineDiv.classList.add('editor-line');
+                        lineDiv.setAttribute('contenteditable', 'true');
+                        lineDiv.setAttribute('data-markdown', lineText);
+                        lineDiv.textContent = lineText;
+                        this.editor.appendChild(lineDiv);
+                        
+                        // 各行をHTML変換してプレビュー表示
+                        setTimeout(() => {
+                            this.convertLineToHTML(lineDiv);
+                        }, 50 * index); // 少し間隔を空けて順次変換
+                    });
+                } else {
+                    // 初期化時に最初の行を作成
+                    this.ensureLineStructure();
+                }
+            }
+
+            handleKeydown(e) {
+                console.log('Key pressed:', e.key);
+                
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    
+                    // 現在の行をHTML変換してから新しい行を作成
+                    const currentLine = this.getCurrentLine();
+                    if (currentLine) {
+                        this.convertLineToHTML(currentLine);
+                    }
+                    
+                    // 新しい行を作成
+                    this.createNewLine();
+                }
+            }
+
+            handleKeyup(e) {
+                // 矢印キーでの行移動を検出
+                if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+                    this.checkLineChange();
+                }
+            }
+
+            handleInput(e) {
+                this.updatePlaceholder();
+                
+                // 現在の行のdata-markdown属性を更新
+                const currentLine = this.getCurrentLine();
+                if (currentLine) {
+                    const currentText = currentLine.textContent || '';
+                    currentLine.setAttribute('data-markdown', currentText);
+                }
+                
+                this.updateHiddenInput();
+            }
+
+            handleClick(e) {
+                // 前の行をHTML変換
+                if (this.currentLineElement) {
+                    this.convertLineToHTML(this.currentLineElement);
+                }
+                
+                // クリックした行をMarkdown表示に戻す
+                const clickedLine = this.getLineFromEvent(e);
+                if (clickedLine) {
+                    this.convertLineToMarkdown(clickedLine);
+                    this.currentLineElement = clickedLine;
+                    
+                    // クリック後にカーソルを最後尾に設定
+                    setTimeout(() => {
+                        this.setCursorToEnd(clickedLine);
+                    }, 10);
+                    
+                    console.log('Clicked line converted to Markdown');
+                }
+            }
+
+            checkLineChange() {
+                const newLine = this.getCurrentLine();
+                if (newLine && newLine !== this.currentLineElement) {
+                    // 前の行をHTML変換
+                    if (this.currentLineElement) {
+                        this.convertLineToHTML(this.currentLineElement);
+                        console.log('Line changed, converting previous line to HTML');
+                    }
+                    
+                    // 新しい行をMarkdown表示に戻す
+                    this.convertLineToMarkdown(newLine);
+                    this.currentLineElement = newLine;
+                    
+                    // カーソルを最後尾に設定
+                    setTimeout(() => {
+                        this.setCursorToEnd(newLine);
+                    }, 10);
+                    
+                    console.log('New line set to Markdown mode');
+                }
+            }
+
+            setCursorToEnd(element) {
+                const range = document.createRange();
+                const sel = window.getSelection();
+                
+                // 要素の最後尾にカーソルを設定
+                if (element.childNodes.length > 0) {
+                    const lastChild = element.childNodes[element.childNodes.length - 1];
+                    if (lastChild.nodeType === Node.TEXT_NODE) {
+                        range.setStart(lastChild, lastChild.textContent.length);
+                    } else {
+                        range.setStart(element, element.childNodes.length);
+                    }
+                } else {
+                    range.setStart(element, 0);
+                }
+                range.collapse(true);
+                
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
+
+            getCurrentLine() {
+                const selection = window.getSelection();
+                if (selection.rangeCount === 0) return null;
+                
+                let node = selection.getRangeAt(0).startContainer;
+                
+                // テキストノードの場合、親要素を取得
+                if (node.nodeType === Node.TEXT_NODE) {
+                    node = node.parentNode;
+                }
+                
+                // 現在の行を見つける
+                while (node && node !== this.editor) {
+                    if (node.classList && node.classList.contains('editor-line')) {
+                        return node;
+                    }
+                    node = node.parentNode;
+                }
+                return null;
+            }
+
+            getLineFromEvent(e) {
+                let target = e.target;
+                while (target && target !== this.editor) {
+                    if (target.classList && target.classList.contains('editor-line')) {
+                        return target;
+                    }
+                    target = target.parentNode;
+                }
+                return null;
+            }
+
+            ensureLineStructure() {
+                if (this.editor.children.length === 0) {
+                    const firstLine = document.createElement('div');
+                    firstLine.classList.add('editor-line');
+                    firstLine.setAttribute('contenteditable', 'true');
+                    firstLine.setAttribute('data-markdown', ''); // 空の原文で初期化
+                    this.editor.appendChild(firstLine);
+                    firstLine.focus();
+                }
+            }
+
+            createNewLine() {
+                const newLine = document.createElement('div');
+                newLine.classList.add('editor-line');
+                newLine.setAttribute('contenteditable', 'true');
+                newLine.setAttribute('data-markdown', ''); // 空の原文で初期化
+                
+                // カーソル位置の後に挿入
+                const selection = window.getSelection();
+                if (selection.rangeCount > 0) {
+                    const range = selection.getRangeAt(0);
+                    let currentLine = range.startContainer;
+                    
+                    if (currentLine.nodeType === Node.TEXT_NODE) {
+                        currentLine = currentLine.parentNode;
+                    }
+                    
+                    while (currentLine && !currentLine.classList.contains('editor-line')) {
+                        currentLine = currentLine.parentNode;
+                    }
+                    
+                    if (currentLine) {
+                        currentLine.parentNode.insertBefore(newLine, currentLine.nextSibling);
+                    } else {
+                        this.editor.appendChild(newLine);
+                    }
+                } else {
+                    this.editor.appendChild(newLine);
+                }
+                
+                // 新しい行にカーソルを設定（最後尾に）
+                setTimeout(() => {
+                    const range = document.createRange();
+                    const sel = window.getSelection();
+                    
+                    // 行の最後尾にカーソルを設定
+                    if (newLine.childNodes.length > 0) {
+                        const lastChild = newLine.childNodes[newLine.childNodes.length - 1];
+                        if (lastChild.nodeType === Node.TEXT_NODE) {
+                            range.setStart(lastChild, lastChild.textContent.length);
+                        } else {
+                            range.setStart(newLine, newLine.childNodes.length);
+                        }
+                    } else {
+                        range.setStart(newLine, 0);
+                    }
+                    range.collapse(true);
+                    
+                    sel.removeAllRanges();
+                    sel.addRange(range);
+                    
+                    newLine.focus();
+                    this.currentLineElement = newLine;
+                    
+                    console.log('New line created and focused at end');
+                }, 10);
+            }
+
+            async convertLineToHTML(lineElement) {
+                if (this.isConverting || !lineElement) return;
+                
+                const markdown = lineElement.textContent.trim();
+                if (!markdown) return;
+                
+                console.log('Converting to HTML:', markdown);
+                
+                try {
+                    this.isConverting = true;
+                    
+                    // Markdownの原文を保存
+                    lineElement.setAttribute('data-markdown', markdown);
+                    
+                    // コードブロック内かどうかチェック
+                    if (this.isLineInCodeBlock(lineElement)) {
+                        // コードブロック内の行は変換しない
+                        console.log('Line is in code block, skipping conversion');
+                        return;
+                    }
+                    
+                    // 通常のHTML変換を実行
+                    const html = this.simpleMarkdownToHTML(markdown);
+                    if (html !== markdown) {
+                        lineElement.innerHTML = html;
+                        lineElement.classList.add('markdown-rendered');
+                        console.log('Line converted to HTML');
+                    }
+                    
+                } catch (error) {
+                    console.error('Markdown conversion error:', error);
+                } finally {
+                    this.isConverting = false;
+                }
+            }
+
+            isLineInCodeBlock(lineElement) {
+                // 現在の行がコードブロック内かどうかを判定
+                const lines = this.editor.querySelectorAll('.editor-line');
+                let inCodeBlock = false;
+                
+                for (let line of lines) {
+                    const text = line.getAttribute('data-markdown') || line.textContent.trim();
+                    
+                    if (text.startsWith('```')) {
+                        if (line === lineElement) {
+                            // 現在の行が```の行の場合は変換しない
+                            return true;
+                        }
+                        inCodeBlock = !inCodeBlock;
+                    } else if (line === lineElement) {
+                        return inCodeBlock;
+                    }
+                }
+                
+                return false;
+            }
+
+            simpleMarkdownToHTML(markdown) {
+                return markdown
+                    // 見出し（最初に処理）
+                    .replace(/^#### (.*$)/gm, '<span class="text-base font-bold">$1</span>')
+                    .replace(/^### (.*$)/gm, '<span class="text-lg font-bold">$1</span>')
+                    .replace(/^## (.*$)/gm, '<span class="text-xl font-bold">$1</span>')
+                    .replace(/^# (.*$)/gm, '<span class="text-2xl font-bold">$1</span>')
+                    
+                    // 引用
+                    .replace(/^> (.*$)/gm, '<div class="border-l-4 border-gray-300 pl-4 italic text-gray-600">$1</div>')
+                    
+                    // 水平線
+                    .replace(/^---$/gm, '<hr class="border-gray-300 my-2">')
+                    .replace(/^\*\*\*$/gm, '<hr class="border-gray-300 my-2">')
+                    
+                    // リスト
+                    .replace(/^- (.*$)/gm, '<span class="flex items-start"><span class="mr-2">•</span><span>$1</span></span>')
+                    .replace(/^\* (.*$)/gm, '<span class="flex items-start"><span class="mr-2">•</span><span>$1</span></span>')
+                    .replace(/^\+ (.*$)/gm, '<span class="flex items-start"><span class="mr-2">•</span><span>$1</span></span>')
+                    .replace(/^(\d+)\. (.*$)/gm, '<span class="flex items-start"><span class="mr-2">$1.</span><span>$2</span></span>')
+                    
+                    // チェックボックス
+                    .replace(/^- \[ \] (.*$)/gm, '<span class="flex items-start"><span class="mr-2">☐</span><span>$1</span></span>')
+                    .replace(/^- \[x\] (.*$)/gm, '<span class="flex items-start"><span class="mr-2">☑</span><span class="line-through">$1</span></span>')
+                    
+                    // インライン要素（最後に処理）
+                    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+                    .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                    .replace(/`(.*?)`/g, '<code class="bg-gray-200 px-1 rounded">$1</code>')
+                    .replace(/~~(.*?)~~/g, '<span class="line-through">$1</span>')
+                    
+                    // リンク
+                    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-blue-600 underline">$1</a>');
+            }
+
+            convertLineToMarkdown(lineElement) {
+                if (lineElement && lineElement.classList.contains('markdown-rendered')) {
+                    const markdown = lineElement.getAttribute('data-markdown');
+                    if (markdown) {
+                        lineElement.textContent = markdown;
+                        // data-markdown属性も更新（textContentと一致させる）
+                        lineElement.setAttribute('data-markdown', markdown);
+                        lineElement.classList.remove('markdown-rendered');
+                        console.log('Line converted back to Markdown');
+                    }
+                } else if (lineElement) {
+                    // HTML変換されていない行も、data-markdown属性を現在のtextContentで更新
+                    const currentText = lineElement.textContent || '';
+                    lineElement.setAttribute('data-markdown', currentText);
+                }
+            }
+
+            convertAllLinesToMarkdown() {
+                const lines = this.editor.querySelectorAll('.editor-line');
+                lines.forEach(line => {
+                    this.convertLineToMarkdown(line);
+                });
+                this.updateHiddenInput();
+            }
+
+            updateHiddenInput() {
+                const lines = this.editor.querySelectorAll('.editor-line');
+                const contentLines = Array.from(lines).map(line => {
+                    // data-markdown属性がある場合は原文を使用、なければtextContentを使用
+                    const markdown = line.getAttribute('data-markdown');
+                    const text = markdown || line.textContent || '';
+                    // 空行も含めて保持する
+                    return text;
+                });
+                
+                // 最後の空行を除去しない（すべての行を保持）
+                const content = contentLines.join('\n');
+                this.hiddenInput.value = content;
+                console.log('Hidden input updated lines:', contentLines);
+                console.log('Hidden input final content:', content);
+            }
+
+            updatePlaceholder() {
+                const isEmpty = !this.editor.textContent.trim();
+                if (isEmpty) {
+                    this.editor.classList.add('empty');
+                } else {
+                    this.editor.classList.remove('empty');
+                }
+            }
+        }
+
+        // エディターを初期化
+        new MarkdownEditor();
     </script>
+
+    <style>
+        #body-editor.empty:before {
+            content: attr(data-placeholder);
+            color: #9ca3af;
+            pointer-events: none;
+        }
+        
+        .editor-line {
+            min-height: 1.5em;
+            margin: 2px 0;
+            outline: none;
+        }
+        
+        .editor-line.markdown-rendered {
+            /* 変換された行のスタイルを削除 - 通常のテキストと同じ見た目に */
+        }
+        
+        #body-editor:focus {
+            outline: none;
+        }
+    </style>
 @endsection

--- a/private-wiki/routes/web.php
+++ b/private-wiki/routes/web.php
@@ -24,4 +24,7 @@ Route::middleware('auth')->group(function () {
     
     // タグ候補API
     Route::get('/tags', [TagController::class, 'index']);
+    
+    // Markdown変換API
+    Route::post('/api/markdown', [NoteController::class, 'convertMarkdown']);
 });


### PR DESCRIPTION
## Summary
- 記事作成・編集画面で行ごとのリアルタイムMarkdownプレビュー機能を実装
- カーソルが離れた行は自動的にHTML表示、カーソルが当たった行は原文表示に切り替え
- コードブロック内は変換を行わず原文のまま表示
- 保存時は確実に原文のMarkdownデータを送信
- 表示時の改行処理を改善し、行ごとの段落区切りを正しく表示

## 主な変更内容
### フロントエンド
- `contenteditable`を使用した行ベースのMarkdownエディター実装
- JavaScript製エディタークラスで行ごとの状態管理
- リアルタイムプレビュー機能（見出し、太字、リスト、コードブロック等に対応）
- 編集画面での既存データの自動プレビュー表示

### バックエンド  
- CommonMarkConverterの改行処理改善
- 単一改行を段落区切りとして扱うよう修正
- Markdown変換API エンドポイント追加

### UI/UX改善
- カーソル位置を行末に自動設定
- エンターキーでの新行作成とプレビュー変換
- クリック時の原文復元機能

## Test plan
- [x] 記事作成画面でのMarkdown入力・プレビュー動作確認
- [x] 編集画面での既存データ読み込み・プレビュー確認  
- [x] 保存時の原文データ送信確認
- [x] 表示画面での改行処理確認
- [x] コードブロック内での変換無効化確認

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)