### PR TITLE
[Issue #27] 記事削除後に発生するエラーを修正

### DIFF
--- a/private-wiki/app/Models/Note.php
+++ b/private-wiki/app/Models/Note.php
@@ -22,7 +22,7 @@ class Note extends Model
             $note->createHistory('updated');
         });
 
-        static::deleted(function ($note) {
+        static::deleting(function ($note) {
             $note->createHistory('deleted');
         });
     }


### PR DESCRIPTION
## 概要
記事削除後に発生していたエラーを修正しました。

## 問題
- ノート削除処理実行後にエラーが発生していた
- 削除処理自体は正常に完了していたが、履歴作成時にエラーが発生

## 原因
`Note`モデルの`deleted`イベントで削除後に履歴を作成しようとしていたが、既に削除されたノートで`$this->id`を参照しようとしてエラーが発生していた。

## 修正内容
- `deleted`イベントを`deleting`イベントに変更
- 削除前にノートの情報が利用可能な状態で履歴を作成するよう修正

## 影響範囲
- 記事削除機能（notes/{id}/destroy）
- ノート履歴管理機能

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)