### PR TITLE
[Issue #29] バグ投稿タイムライン機能を実装

### DIFF
--- a/private-wiki/app/Http/Controllers/BugTimelineController.php
+++ b/private-wiki/app/Http/Controllers/BugTimelineController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\BugReport;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class BugTimelineController extends Controller
+{
+    public function index(): View
+    {
+        $bugReports = BugReport::latest()->get();
+        
+        return view('bug-timeline.index', compact('bugReports'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+        ]);
+
+        BugReport::create([
+            'title' => $request->title,
+            'description' => $request->description,
+            'status' => 'open',
+        ]);
+
+        return redirect('/bug-timeline')
+            ->with('success', 'バグレポートを投稿しました。');
+    }
+
+    public function updateStatus(Request $request, BugReport $bugReport): RedirectResponse
+    {
+        $request->validate([
+            'status' => 'required|in:open,closed',
+        ]);
+
+        $bugReport->update([
+            'status' => $request->status,
+        ]);
+
+        return redirect('/bug-timeline')
+            ->with('success', 'ステータスを更新しました。');
+    }
+
+    public function destroy(BugReport $bugReport): RedirectResponse
+    {
+        $bugReport->delete();
+
+        return redirect('/bug-timeline')
+            ->with('success', 'バグレポートを削除しました。');
+    }
+}

--- a/private-wiki/app/Models/BugReport.php
+++ b/private-wiki/app/Models/BugReport.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BugReport extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'status',
+    ];
+
+    protected $attributes = [
+        'status' => 'open',
+    ];
+}

--- a/private-wiki/database/migrations/2025_08_24_102724_create_bug_reports_table.php
+++ b/private-wiki/database/migrations/2025_08_24_102724_create_bug_reports_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('bug_reports', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description');
+            $table->enum('status', ['open', 'closed'])->default('open');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('bug_reports');
+    }
+};

--- a/private-wiki/public/css/app.css
+++ b/private-wiki/public/css/app.css
@@ -1339,6 +1339,10 @@ video {
   height: 2rem;
 }
 
+.h-2 {
+  height: 0.5rem;
+}
+
 .max-h-40 {
   max-height: 10rem;
 }
@@ -1387,6 +1391,10 @@ video {
   width: 2rem;
 }
 
+.w-2 {
+  width: 0.5rem;
+}
+
 .min-w-32 {
   min-width: 8rem;
 }
@@ -1401,6 +1409,10 @@ video {
 
 .max-w-sm {
   max-width: 24rem;
+}
+
+.max-w-4xl {
+  max-width: 56rem;
 }
 
 .flex-1 {
@@ -1533,6 +1545,24 @@ video {
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
 
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
 .self-start {
   align-self: flex-start;
 }
@@ -1545,6 +1575,10 @@ video {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
 }
 
 .rounded {
@@ -1655,6 +1689,16 @@ video {
 .border-gray-600 {
   --tw-border-opacity: 1;
   border-color: rgb(75 85 99 / var(--tw-border-opacity, 1));
+}
+
+.border-green-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(22 163 74 / var(--tw-border-opacity, 1));
+}
+
+.border-red-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(220 38 38 / var(--tw-border-opacity, 1));
 }
 
 .bg-blue-100 {
@@ -1820,6 +1864,11 @@ video {
   padding-right: 0.25rem;
 }
 
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
 .pt-4 {
   padding-top: 1rem;
 }
@@ -1869,6 +1918,11 @@ video {
 .text-base {
   font-size: 1rem;
   line-height: 1.5rem;
+}
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
 }
 
 .font-bold {
@@ -1989,6 +2043,11 @@ video {
 .text-blue-400 {
   --tw-text-opacity: 1;
   color: rgb(96 165 250 / var(--tw-text-opacity, 1));
+}
+
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity, 1));
 }
 
 .underline {
@@ -2188,6 +2247,16 @@ video {
   background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
 }
 
+.hover\:bg-green-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(240 253 244 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-red-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
+}
+
 .hover\:text-gray-400:hover {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
@@ -2236,6 +2305,11 @@ video {
 .hover\:text-gray-300:hover {
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-gray-800:hover {
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
 }
 
 .focus\:z-10:focus {

--- a/private-wiki/resources/views/bug-timeline/index.blade.php
+++ b/private-wiki/resources/views/bug-timeline/index.blade.php
@@ -1,0 +1,151 @@
+@extends('layouts.app')
+
+@section('title', 'バグタイムライン')
+
+@section('content')
+<div class="max-w-4xl">
+    <h1 class="text-3xl font-bold text-gray-900 mb-8">🐛 バグタイムライン</h1>
+    
+    {{-- バグ投稿フォーム --}}
+    <div class="bg-white rounded-lg shadow-sm p-6 mb-8">
+        <h2 class="text-xl font-semibold mb-4">新しいバグを報告</h2>
+        
+        <form method="POST" action="{{ route('bug-timeline.store') }}" class="space-y-4">
+            @csrf
+            
+            <div>
+                <label for="title" class="block text-sm font-medium text-gray-700 mb-1">
+                    タイトル <span class="text-red-500">*</span>
+                </label>
+                <input type="text" 
+                       id="title" 
+                       name="title" 
+                       value="{{ old('title') }}"
+                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                       placeholder="バグの概要を入力してください"
+                       required>
+                @error('title')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
+            </div>
+            
+            <div>
+                <label for="description" class="block text-sm font-medium text-gray-700 mb-1">
+                    詳細 <span class="text-red-500">*</span>
+                </label>
+                <textarea id="description" 
+                          name="description" 
+                          rows="4"
+                          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                          placeholder="バグの詳細、再現手順、期待する動作などを記載してください"
+                          required>{{ old('description') }}</textarea>
+                @error('description')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
+            </div>
+            
+            <div class="flex justify-end">
+                <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-md font-medium">
+                    投稿する
+                </button>
+            </div>
+        </form>
+    </div>
+    
+    {{-- バグタイムライン --}}
+    <div class="space-y-6">
+        @forelse($bugReports as $bugReport)
+            <div class="bg-white rounded-lg shadow-sm p-6">
+                <div class="flex justify-between items-start mb-4">
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900 mb-2">{{ $bugReport->title }}</h3>
+                        <div class="flex items-center space-x-4 text-sm text-gray-500">
+                            <span class="flex items-center">
+                                <span class="w-2 h-2 rounded-full mr-2 {{ $bugReport->status === 'open' ? 'bg-red-500' : 'bg-green-500' }}"></span>
+                                {{ $bugReport->status === 'open' ? 'オープン' : 'クローズ' }}
+                            </span>
+                            <span>{{ $bugReport->created_at->format('Y-m-d H:i') }}</span>
+                        </div>
+                    </div>
+                    
+                    <div class="flex space-x-2">
+                        {{-- ステータス更新フォーム --}}
+                        <form method="POST" action="{{ route('bug-timeline.update-status', $bugReport) }}" class="inline">
+                            @csrf
+                            @method('PATCH')
+                            <input type="hidden" name="status" value="{{ $bugReport->status === 'open' ? 'closed' : 'open' }}">
+                            <button type="submit" 
+                                    class="text-sm px-3 py-1 rounded border {{ $bugReport->status === 'open' ? 'border-green-600 text-green-600 hover:bg-green-50' : 'border-red-600 text-red-600 hover:bg-red-50' }}">
+                                {{ $bugReport->status === 'open' ? '解決済みにする' : '再オープンする' }}
+                            </button>
+                        </form>
+                        
+                        {{-- 削除ボタンとモーダル --}}
+                        <div x-data="{ showDeleteConfirm: false }">
+                            <button @click="showDeleteConfirm = true" 
+                                    class="text-sm px-3 py-1 rounded border border-red-600 text-red-600 hover:bg-red-50">
+                                削除
+                            </button>
+                            
+                            {{-- 削除確認モーダル --}}
+                            <div x-show="showDeleteConfirm" 
+                                 x-transition.opacity.duration.300ms 
+                                 class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center" 
+                                 style="display: none;">
+                                <div @click.away="showDeleteConfirm = false" 
+                                     x-transition:enter="transition ease-out duration-300"
+                                     x-transition:enter-start="opacity-0 transform scale-90" 
+                                     x-transition:enter-end="opacity-100 transform scale-100"
+                                     x-transition:leave="transition ease-in duration-200"
+                                     x-transition:leave-start="opacity-100 transform scale-100" 
+                                     x-transition:leave-end="opacity-0 transform scale-90"
+                                     class="bg-white rounded-lg p-6 max-w-sm mx-4 shadow-xl">
+                                    
+                                    <div class="flex items-center mb-4">
+                                        <svg class="w-8 h-8 text-red-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                                                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z">
+                                            </path>
+                                        </svg>
+                                        <h3 class="text-lg font-semibold text-gray-900">バグレポートの削除</h3>
+                                    </div>
+                                    
+                                    <p class="text-gray-600 mb-6">
+                                        「{{ $bugReport->title }}」を削除してもよろしいですか？<br>
+                                        この操作は取り消せません。
+                                    </p>
+                                    
+                                    <div class="flex justify-end space-x-3">
+                                        <button @click="showDeleteConfirm = false" 
+                                                class="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors duration-200">
+                                            キャンセル
+                                        </button>
+                                        
+                                        <form method="POST" action="{{ route('bug-timeline.destroy', $bugReport) }}" class="inline">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" 
+                                                    class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 transition-colors duration-200">
+                                                削除する
+                                            </button>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="text-gray-700">
+                    <p class="whitespace-pre-wrap">{{ $bugReport->description }}</p>
+                </div>
+            </div>
+        @empty
+            <div class="text-center py-12">
+                <p class="text-gray-500 text-lg">バグレポートがありません</p>
+                <p class="text-gray-400 text-sm mt-2">上記のフォームから新しいバグを報告してください</p>
+            </div>
+        @endforelse
+    </div>
+</div>
+@endsection

--- a/private-wiki/resources/views/layouts/app.blade.php
+++ b/private-wiki/resources/views/layouts/app.blade.php
@@ -24,6 +24,7 @@
         <nav class="space-y-2">
             <a href="{{ url('/') }}" class="block hover:bg-gray-700 rounded px-2 py-1">ホーム</a>
             <a href="#" class="block hover:bg-gray-700 rounded px-2 py-1">メモ一覧</a>
+            <a href="{{ route('bug-timeline.index') }}" class="block hover:bg-gray-700 rounded px-2 py-1">🐛 バグタイムライン</a>
             <a href="#" class="block hover:bg-gray-700 rounded px-2 py-1">設定</a>
         </nav>
         

--- a/private-wiki/routes/web.php
+++ b/private-wiki/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthController;
+use App\Http\Controllers\BugTimelineController;
 use App\Http\Controllers\NoteController;
 use App\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
@@ -24,6 +25,12 @@ Route::middleware('auth')->group(function () {
     
     // タグ候補API
     Route::get('/tags', [TagController::class, 'index']);
+    
+    // バグタイムライン
+    Route::get('/bug-timeline', [BugTimelineController::class, 'index'])->name('bug-timeline.index');
+    Route::post('/bug-timeline', [BugTimelineController::class, 'store'])->name('bug-timeline.store');
+    Route::patch('/bug-timeline/{bugReport}/status', [BugTimelineController::class, 'updateStatus'])->name('bug-timeline.update-status');
+    Route::delete('/bug-timeline/{bugReport}', [BugTimelineController::class, 'destroy'])->name('bug-timeline.destroy');
     
     // Markdown変換API
     Route::post('/api/markdown', [NoteController::class, 'convertMarkdown']);

--- a/private-wiki/tests/Feature/BugTimelineTest.php
+++ b/private-wiki/tests/Feature/BugTimelineTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\BugReport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class BugTimelineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    /** @test */
+    public function it_can_display_bug_timeline_page()
+    {
+        $response = $this->get('/bug-timeline');
+        
+        $response->assertStatus(200);
+        $response->assertViewIs('bug-timeline.index');
+    }
+
+    /** @test */
+    public function it_can_create_bug_report_via_post_request()
+    {
+        $response = $this->post('/bug-timeline', [
+            'title' => 'Test Bug',
+            'description' => 'This is a test bug description',
+        ]);
+
+        $response->assertRedirect('/bug-timeline');
+        $response->assertSessionHas('success', 'バグレポートを投稿しました。');
+        
+        $this->assertDatabaseHas('bug_reports', [
+            'title' => 'Test Bug',
+            'description' => 'This is a test bug description',
+            'status' => 'open',
+        ]);
+    }
+
+    /** @test */
+    public function it_validates_required_fields()
+    {
+        $response = $this->post('/bug-timeline', []);
+
+        $response->assertSessionHasErrors(['title', 'description']);
+    }
+
+    /** @test */
+    public function it_displays_bug_reports_in_timeline_order()
+    {
+        // より古いバグレポートを作成
+        BugReport::create([
+            'title' => 'Older Bug',
+            'description' => 'Older description',
+        ]);
+        
+        // 1秒待機
+        sleep(1);
+        
+        // より新しいバグレポートを作成
+        BugReport::create([
+            'title' => 'Newer Bug', 
+            'description' => 'Newer description',
+        ]);
+
+        $response = $this->get('/bug-timeline');
+        
+        $response->assertSeeInOrder(['Newer Bug', 'Older Bug']);
+    }
+
+    /** @test */
+    public function it_can_update_bug_status()
+    {
+        $bugReport = BugReport::create([
+            'title' => 'Test Bug',
+            'description' => 'Test description',
+            'status' => 'open',
+        ]);
+
+        $response = $this->patch("/bug-timeline/{$bugReport->id}/status", [
+            'status' => 'closed',
+        ]);
+
+        $response->assertRedirect('/bug-timeline');
+        $this->assertDatabaseHas('bug_reports', [
+            'id' => $bugReport->id,
+            'status' => 'closed',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_delete_bug_report()
+    {
+        $bugReport = BugReport::create([
+            'title' => 'Test Bug to Delete',
+            'description' => 'This bug will be deleted',
+            'status' => 'open',
+        ]);
+
+        $response = $this->delete("/bug-timeline/{$bugReport->id}");
+
+        $response->assertRedirect('/bug-timeline');
+        $response->assertSessionHas('success', 'バグレポートを削除しました。');
+        
+        $this->assertDatabaseMissing('bug_reports', [
+            'id' => $bugReport->id,
+        ]);
+    }
+}

--- a/private-wiki/tests/Unit/BugReportTest.php
+++ b/private-wiki/tests/Unit/BugReportTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\BugReport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class BugReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_can_create_a_bug_report()
+    {
+        $bugReport = BugReport::create([
+            'title' => 'Sample Bug',
+            'description' => 'This is a sample bug description',
+            'status' => 'open',
+        ]);
+
+        $this->assertInstanceOf(BugReport::class, $bugReport);
+        $this->assertEquals('Sample Bug', $bugReport->title);
+        $this->assertEquals('This is a sample bug description', $bugReport->description);
+        $this->assertEquals('open', $bugReport->status);
+    }
+
+    /** @test */
+    public function it_has_required_fields()
+    {
+        $requiredFields = ['title', 'description'];
+        
+        foreach ($requiredFields as $field) {
+            $data = [
+                'title' => 'Sample Bug',
+                'description' => 'This is a sample bug description',
+                'status' => 'open',
+            ];
+            unset($data[$field]);
+            
+            $this->expectException(\Illuminate\Database\QueryException::class);
+            BugReport::create($data);
+        }
+    }
+
+    /** @test */
+    public function it_has_default_status_open()
+    {
+        $bugReport = BugReport::create([
+            'title' => 'Sample Bug',
+            'description' => 'This is a sample bug description',
+        ]);
+
+        $this->assertEquals('open', $bugReport->status);
+    }
+
+    /** @test */
+    public function it_can_be_ordered_by_created_at_desc()
+    {
+        $first = BugReport::create([
+            'title' => 'First Bug',
+            'description' => 'First description',
+        ]);
+        sleep(1);
+
+        $second = BugReport::create([
+            'title' => 'Second Bug',
+            'description' => 'Second description',
+        ]);
+
+        $ordered = BugReport::latest()->get();
+        
+        $this->assertEquals('Second Bug', $ordered->first()->title);
+        $this->assertEquals('First Bug', $ordered->last()->title);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #29「バグ投稿タイムラインを作成したい」を解決するため、バグレポート投稿・管理機能を実装しました。

## 実装した機能
- ✅ バグレポートの投稿機能（タイトル・詳細入力）
- ✅ タイムライン表示（日時による新しい順並び替え）
- ✅ ステータス管理（open/closed切り替え）
- ✅ バグレポート削除機能（モーダル確認付き）
- ✅ サイドバーナビゲーション統合

## 受け入れ条件の達成状況
- [x] バグ投稿のタイムライン表示機能
- [x] 日時による並び替え機能  
- [x] 適切なUI/UXでの表示

## 技術仕様
- **フロントエンド**: Alpine.js + Tailwind CSS
- **バックエンド**: Laravel 12 + SQLite
- **開発手法**: TDDによる実装
- **デザイン**: 既存の記事削除機能と統一されたモーダル

## テスト結果
- **ユニットテスト**: 4件通過（BugReportモデル）
- **フィーチャーテスト**: 6件通過（BugTimelineController）
- **総テスト件数**: 14件通過（30アサーション）

## スクリーンショット
- `/bug-timeline` でアクセス可能
- サイドバーに「🐛 バグタイムライン」リンクを追加
- 投稿フォーム + タイムライン表示の統合UI
- 記事削除と同じデザインのモーダル削除確認

## Test plan
- [ ] バグレポート投稿機能の動作確認
- [ ] タイムライン表示の時系列順序確認
- [ ] ステータス切り替え機能の確認
- [ ] 削除モーダルの動作確認
- [ ] サイドバーナビゲーションの確認
- [ ] レスポンシブデザインの確認

🤖 Generated with [Claude Code](https://claude.ai/code)