### PR TITLE
[Issue #31] サイドバーお気に入りタグ機能の実装

### DIFF
--- a/private-wiki/app/Http/Controllers/FavoriteTagController.php
+++ b/private-wiki/app/Http/Controllers/FavoriteTagController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class FavoriteTagController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $favoriteTags = FavoriteTag::with('tag')->ordered()->get();
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $favoriteTags
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'tag_id' => [
+                'required',
+                'integer',
+                Rule::exists('tags', 'id'),
+                Rule::unique('favorite_tags', 'tag_id')
+            ]
+        ]);
+
+        try {
+            $favoriteTag = FavoriteTag::create([
+                'tag_id' => $request->tag_id,
+                'display_order' => FavoriteTag::getNextDisplayOrder()
+            ]);
+
+            $favoriteTag->load('tag');
+
+            return response()->json([
+                'status' => 'success',
+                'data' => $favoriteTag
+            ], 201);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'このタグは既にお気に入りに登録されています'
+            ], 422);
+        }
+    }
+
+    public function destroy($id): JsonResponse
+    {
+        $favoriteTag = FavoriteTag::find($id);
+        
+        if (!$favoriteTag) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'お気に入りタグが見つかりません'
+            ], 404);
+        }
+        
+        $favoriteTag->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'お気に入りタグを削除しました'
+        ]);
+    }
+
+    public function reorder(Request $request): JsonResponse
+    {
+        $request->validate([
+            'favorite_tag_ids' => 'required|array',
+            'favorite_tag_ids.*' => 'integer|exists:favorite_tags,id'
+        ]);
+
+        FavoriteTag::reorderTags($request->favorite_tag_ids);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'お気に入りタグの順序を変更しました'
+        ]);
+    }
+
+    public function manage()
+    {
+        $favoriteTags = FavoriteTag::with('tag')->ordered()->get();
+        
+        $favoriteTagIds = $favoriteTags->pluck('tag_id');
+        $availableTags = Tag::whereNotIn('id', $favoriteTagIds)->orderBy('name')->get();
+
+        return view('favorite-tags.manage', compact('favoriteTags', 'availableTags'));
+    }
+
+    public function add(Request $request)
+    {
+        // 現在のお気に入りタグ数をチェック
+        $currentCount = FavoriteTag::count();
+        if ($currentCount >= 5) {
+            return redirect('/favorite-tags/manage')
+                ->with('error', 'お気に入りタグは最大5個までしか登録できません');
+        }
+
+        $request->validate([
+            'tag_name' => [
+                'required',
+                'string',
+                'max:255'
+            ]
+        ]);
+
+        // タグ名からタグを検索または作成
+        $tag = Tag::firstOrCreate(['name' => $request->tag_name]);
+        
+        // 既にお気に入りに追加されているかチェック
+        if (FavoriteTag::where('tag_id', $tag->id)->exists()) {
+            return redirect('/favorite-tags/manage')
+                ->with('error', 'このタグは既にお気に入りに登録されています');
+        }
+
+        FavoriteTag::create([
+            'tag_id' => $tag->id,
+            'display_order' => FavoriteTag::getNextDisplayOrder()
+        ]);
+
+        return redirect('/favorite-tags/manage')
+            ->with('success', 'お気に入りタグに追加しました');
+    }
+
+    public function remove(FavoriteTag $favoriteTag)
+    {
+        $favoriteTag->delete();
+
+        return redirect('/favorite-tags/manage')
+            ->with('success', 'お気に入りタグから削除しました');
+    }
+
+}

--- a/private-wiki/app/Http/Controllers/NoteController.php
+++ b/private-wiki/app/Http/Controllers/NoteController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\FavoriteTag;
 use App\Models\Note;
 use App\Models\Tag;
 use App\Models\NoteHistory;
@@ -45,8 +46,9 @@ class NoteController extends Controller
         }
 
         $notes = $query->orderBy('updated_at', 'desc')->paginate(30)->appends($request->all());
+        $favoriteTags = FavoriteTag::with('tag')->ordered()->get();
 
-        return view('home', compact('notes'));
+        return view('home', compact('notes', 'favoriteTags'));
     }
 
     public function show($id)

--- a/private-wiki/app/Http/Controllers/TagController.php
+++ b/private-wiki/app/Http/Controllers/TagController.php
@@ -12,9 +12,10 @@ class TagController extends Controller
     {
         $query = Tag::query();
 
-        // クエリパラメータ "query" があれば部分一致で絞り込み
-        if ($request->filled('query')) {
-            $query->where('name', 'like', '%'.$request->input('query').'%');
+        // クエリパラメータ "query" または "search" があれば部分一致で絞り込み
+        $searchTerm = $request->input('query') ?? $request->input('search');
+        if ($searchTerm) {
+            $query->where('name', 'like', '%'.$searchTerm.'%');
         }
 
         // 最大10件まで返す

--- a/private-wiki/app/Models/FavoriteTag.php
+++ b/private-wiki/app/Models/FavoriteTag.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FavoriteTag extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tag_id',
+        'display_order',
+    ];
+
+    public function tag(): BelongsTo
+    {
+        return $this->belongsTo(Tag::class);
+    }
+
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('display_order');
+    }
+
+    public static function getNextDisplayOrder(): int
+    {
+        return static::max('display_order') + 1 ?? 1;
+    }
+
+    public static function reorderTags(array $favoriteTagIds): void
+    {
+        foreach ($favoriteTagIds as $index => $favoriteTagId) {
+            static::where('id', $favoriteTagId)->update(['display_order' => $index + 1]);
+        }
+    }
+}

--- a/private-wiki/database/factories/FavoriteTagFactory.php
+++ b/private-wiki/database/factories/FavoriteTagFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class FavoriteTagFactory extends Factory
+{
+    protected $model = FavoriteTag::class;
+
+    public function definition(): array
+    {
+        return [
+            'tag_id' => Tag::factory(),
+            'display_order' => $this->faker->numberBetween(1, 100),
+        ];
+    }
+}

--- a/private-wiki/database/migrations/2025_08_24_133245_create_favorite_tags_table.php
+++ b/private-wiki/database/migrations/2025_08_24_133245_create_favorite_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('favorite_tags', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+            $table->integer('display_order');
+            $table->timestamps();
+
+            $table->unique('tag_id');
+            $table->index('display_order');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('favorite_tags');
+    }
+};

--- a/private-wiki/database/seeders/FavoriteTagSeeder.php
+++ b/private-wiki/database/seeders/FavoriteTagSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use Illuminate\Database\Seeder;
+
+class FavoriteTagSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // テスト用のタグを作成
+        $tags = [
+            ['name' => 'Laravel', 'order' => 1],
+            ['name' => 'PHP', 'order' => 2], 
+            ['name' => 'JavaScript', 'order' => 3],
+        ];
+
+        foreach ($tags as $tagData) {
+            $tag = Tag::firstOrCreate(['name' => $tagData['name']]);
+            
+            // お気に入りタグが既に存在しない場合のみ作成
+            if (!FavoriteTag::where('tag_id', $tag->id)->exists()) {
+                FavoriteTag::create([
+                    'tag_id' => $tag->id,
+                    'display_order' => $tagData['order']
+                ]);
+            }
+        }
+    }
+}

--- a/private-wiki/public/css/app.css
+++ b/private-wiki/public/css/app.css
@@ -1283,6 +1283,14 @@ video {
   margin-bottom: 0.25rem;
 }
 
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
+}
+
 .block {
   display: block;
 }
@@ -1457,6 +1465,20 @@ video {
   cursor: default;
 }
 
+.cursor-move {
+  cursor: move;
+}
+
+.cursor-grab {
+  cursor: grab;
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
 .list-inside {
   list-style-position: inside;
 }
@@ -1521,6 +1543,10 @@ video {
   gap: 0.75rem;
 }
 
+.gap-8 {
+  gap: 2rem;
+}
+
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
@@ -1561,6 +1587,12 @@ video {
   --tw-space-x-reverse: 0;
   margin-right: calc(0.75rem * var(--tw-space-x-reverse));
   margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0px * var(--tw-space-y-reverse));
 }
 
 .self-start {
@@ -1701,6 +1733,11 @@ video {
   border-color: rgb(220 38 38 / var(--tw-border-opacity, 1));
 }
 
+.border-yellow-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 240 138 / var(--tw-border-opacity, 1));
+}
+
 .bg-blue-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(219 234 254 / var(--tw-bg-opacity, 1));
@@ -1790,6 +1827,16 @@ video {
   background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
 }
 
+.bg-gray-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(75 85 99 / var(--tw-bg-opacity, 1));
+}
+
+.bg-yellow-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 252 232 / var(--tw-bg-opacity, 1));
+}
+
 .bg-opacity-50 {
   --tw-bg-opacity: 0.5;
 }
@@ -1812,6 +1859,10 @@ video {
 
 .p-1 {
   padding: 0.25rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
 }
 
 .px-2 {
@@ -1869,12 +1920,21 @@ video {
   padding-bottom: 3rem;
 }
 
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
 .pt-4 {
   padding-top: 1rem;
 }
 
 .pl-4 {
   padding-left: 1rem;
+}
+
+.text-left {
+  text-align: left;
 }
 
 .text-center {
@@ -2048,6 +2108,21 @@ video {
 .text-green-600 {
   --tw-text-opacity: 1;
   color: rgb(22 163 74 / var(--tw-text-opacity, 1));
+}
+
+.text-blue-200 {
+  --tw-text-opacity: 1;
+  color: rgb(191 219 254 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-800 {
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+.text-yellow-800 {
+  --tw-text-opacity: 1;
+  color: rgb(133 77 14 / var(--tw-text-opacity, 1));
 }
 
 .underline {
@@ -2312,6 +2387,21 @@ video {
   color: rgb(31 41 55 / var(--tw-text-opacity, 1));
 }
 
+.hover\:text-blue-100:hover {
+  --tw-text-opacity: 1;
+  color: rgb(219 234 254 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-red-800:hover {
+  --tw-text-opacity: 1;
+  color: rgb(153 27 27 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-gray-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+
 .focus\:z-10:focus {
   z-index: 10;
 }
@@ -2383,6 +2473,10 @@ video {
   color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
 
+.disabled\:cursor-not-allowed:disabled {
+  cursor: not-allowed;
+}
+
 .disabled\:bg-red-300:disabled {
   --tw-bg-opacity: 1;
   background-color: rgb(252 165 165 / var(--tw-bg-opacity, 1));
@@ -2391,6 +2485,11 @@ video {
 .disabled\:bg-blue-300:disabled {
   --tw-bg-opacity: 1;
   background-color: rgb(147 197 253 / var(--tw-bg-opacity, 1));
+}
+
+.disabled\:bg-gray-400:disabled {
+  --tw-bg-opacity: 1;
+  background-color: rgb(156 163 175 / var(--tw-bg-opacity, 1));
 }
 
 @media (min-width: 640px) {
@@ -2430,6 +2529,12 @@ video {
 
   .md\:flex-row {
     flex-direction: row;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/private-wiki/resources/js/app.js
+++ b/private-wiki/resources/js/app.js
@@ -1,7 +1,19 @@
 import './bootstrap';
 import { SidebarController } from './sidebar.js';
+import { FavoriteTagsController } from './favorite-tags.js';
+import { FavoriteTagsManagement } from './favorite-tags-management.js';
 
-// DOM読み込み完了後にサイドバーコントローラーを初期化
+// DOM読み込み完了後にコントローラーを初期化
 document.addEventListener('DOMContentLoaded', () => {
+    console.log('DOM loaded, initializing controllers...');
     new SidebarController();
+    new FavoriteTagsController();
+    
+    // お気に入りタグ管理ページの場合のみ初期化
+    const favoriteTagsList = document.getElementById('favorite-tags-management-list');
+    console.log('Checking for favorite-tags-management-list:', favoriteTagsList);
+    if (favoriteTagsList) {
+        console.log('Initializing FavoriteTagsManagement...');
+        new FavoriteTagsManagement();
+    }
 });

--- a/private-wiki/resources/js/favorite-tags-management.js
+++ b/private-wiki/resources/js/favorite-tags-management.js
@@ -1,0 +1,364 @@
+export class FavoriteTagsManagement {
+    constructor() {
+        console.log('FavoriteTagsManagement initialized');
+        this.draggedElement = null;
+        this.placeholder = null;
+        this.initializeSortable();
+        this.initializeTagAutocomplete();
+    }
+
+    initializeSortable() {
+        const favoriteTagsList = document.getElementById('favorite-tags-management-list');
+        console.log('favoriteTagsList element:', favoriteTagsList);
+        if (!favoriteTagsList) {
+            console.log('favorite-tags-management-list element not found');
+            return;
+        }
+
+        // Using class properties instead
+
+        // Remove container-level dragstart listener since it's not working
+        // We'll handle this in updateDraggableItems instead
+
+        // dragend will be handled per item as well
+
+        favoriteTagsList.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            
+            if (!this.draggedElement || !this.placeholder) return;
+            
+            // Remove placeholder if already in DOM
+            if (this.placeholder.parentNode) {
+                this.placeholder.parentNode.removeChild(this.placeholder);
+            }
+            
+            const afterElement = this.getDragAfterElement(favoriteTagsList, e.clientY);
+            
+            if (afterElement == null) {
+                favoriteTagsList.appendChild(this.placeholder);
+            } else {
+                favoriteTagsList.insertBefore(this.placeholder, afterElement);
+            }
+        });
+
+        favoriteTagsList.addEventListener('drop', (e) => {
+            e.preventDefault();
+            
+            if (this.draggedElement && this.placeholder && this.placeholder.parentNode) {
+                // Insert the dragged element before the placeholder
+                this.placeholder.parentNode.insertBefore(this.draggedElement, this.placeholder);
+                this.placeholder.remove();
+                
+                // Reset opacity and update order
+                this.draggedElement.style.opacity = '';
+                this.updateOrder();
+            }
+        });
+
+        // Make items draggable by adding draggable attribute
+        this.updateDraggableItems();
+    }
+
+    updateDraggableItems() {
+        const items = document.querySelectorAll('.favorite-tag-item');
+        console.log('Updating draggable items, found:', items.length);
+        
+        items.forEach((item, index) => {
+            console.log(`Setting up item ${index}:`, item);
+            
+            // Always make items draggable with explicit attribute
+            item.setAttribute('draggable', 'true');
+            item.draggable = true;
+            
+            console.log(`Item ${index} draggable attribute:`, item.getAttribute('draggable'));
+            console.log(`Item ${index} draggable property:`, item.draggable);
+            
+            const dragHandle = item.querySelector('.drag-handle');
+            console.log(`Drag handle for item ${index}:`, dragHandle);
+            
+            if (dragHandle) {
+                dragHandle.style.cursor = 'grab';
+                
+                // Add click test
+                dragHandle.addEventListener('click', (e) => {
+                    console.log('Drag handle clicked!');
+                });
+                
+                // Add mousedown listener to handle
+                dragHandle.addEventListener('mousedown', (e) => {
+                    console.log('Mousedown on drag handle');
+                    dragHandle.style.cursor = 'grabbing';
+                    
+                    // Force draggable attribute again on mousedown
+                    item.setAttribute('draggable', 'true');
+                });
+                
+                dragHandle.addEventListener('mouseup', () => {
+                    console.log('Mouseup on drag handle');
+                    dragHandle.style.cursor = 'grab';
+                });
+                
+                // Add dragstart test directly on handle
+                dragHandle.addEventListener('dragstart', (e) => {
+                    console.log('Dragstart on handle!');
+                });
+            }
+            
+            // Add direct dragstart listener to item - this is the main one
+            item.addEventListener('dragstart', (e) => {
+                console.log('Dragstart on item directly!', e.target);
+                this.draggedElement = item;
+                item.style.opacity = '0.5';
+                
+                // Create placeholder
+                this.placeholder = document.createElement('div');
+                this.placeholder.className = 'placeholder bg-blue-100 border-2 border-dashed border-blue-300 p-3 rounded';
+                this.placeholder.innerHTML = '<div class="text-blue-500 text-center text-sm">ここにドロップ</div>';
+                
+                console.log('Created placeholder:', this.placeholder);
+            });
+            
+            // Add dragend listener to item
+            item.addEventListener('dragend', (e) => {
+                console.log('Dragend on item!');
+                item.style.opacity = '';
+                if (this.placeholder && this.placeholder.parentNode) {
+                    this.placeholder.remove();
+                }
+                this.draggedElement = null;
+                this.placeholder = null;
+            });
+        });
+    }
+
+    getDragAfterElement(container, y) {
+        const draggableElements = [...container.querySelectorAll('.favorite-tag-item:not([style*="opacity: 0.5"])')];
+        
+        return draggableElements.reduce((closest, child) => {
+            const box = child.getBoundingClientRect();
+            const offset = y - box.top - box.height / 2;
+            
+            if (offset < 0 && offset > closest.offset) {
+                return { offset: offset, element: child };
+            } else {
+                return closest;
+            }
+        }, { offset: Number.NEGATIVE_INFINITY }).element;
+    }
+
+    updateOrder() {
+        const items = document.querySelectorAll('#favorite-tags-management-list .favorite-tag-item');
+        const favoriteTagIds = Array.from(items).map(item => {
+            const id = parseInt(item.dataset.id);
+            console.log('Item ID:', id, 'Element:', item); // Debug log
+            return id;
+        }).filter(id => !isNaN(id));
+
+        console.log('Reordering with IDs:', favoriteTagIds); // Debug log
+
+        if (favoriteTagIds.length === 0) {
+            console.error('No valid favorite tag IDs found');
+            return;
+        }
+
+        fetch('/api/favorite-tags/reorder', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+            },
+            body: JSON.stringify({
+                favorite_tag_ids: favoriteTagIds
+            })
+        })
+        .then(response => {
+            console.log('Response status:', response.status); // Debug log
+            return response.json();
+        })
+        .then(data => {
+            console.log('Response data:', data); // Debug log
+            if (data.status === 'success') {
+                this.showMessage('順序を更新しました', 'success');
+                // Update sidebar immediately
+                this.updateSidebar();
+            } else {
+                this.showMessage('エラーが発生しました: ' + (data.message || '不明なエラー'), 'error');
+            }
+        })
+        .catch(error => {
+            console.error('Fetch error:', error);
+            this.showMessage('通信エラーが発生しました', 'error');
+        });
+    }
+
+    initializeTagAutocomplete() {
+        const tagInput = document.getElementById('tag_name');
+        const suggestionsList = document.getElementById('tag-suggestions-list');
+        
+        if (!tagInput || !suggestionsList) return;
+
+        let debounceTimer = null;
+
+        tagInput.addEventListener('input', (e) => {
+            const query = e.target.value.trim();
+            
+            if (debounceTimer) {
+                clearTimeout(debounceTimer);
+            }
+
+            debounceTimer = setTimeout(() => {
+                if (query.length >= 1) {
+                    this.fetchTagSuggestions(query, suggestionsList);
+                } else {
+                    suggestionsList.classList.add('hidden');
+                }
+            }, 300);
+        });
+
+        // Hide suggestions when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!tagInput.contains(e.target) && !suggestionsList.contains(e.target)) {
+                suggestionsList.classList.add('hidden');
+            }
+        });
+    }
+
+    fetchTagSuggestions(query, suggestionsList) {
+        fetch(`/tags?search=${encodeURIComponent(query)}`)
+            .then(response => response.json())
+            .then(tags => {
+                this.displaySuggestions(tags, suggestionsList);
+            })
+            .catch(error => {
+                console.error('Error fetching tags:', error);
+                suggestionsList.classList.add('hidden');
+            });
+    }
+
+    displaySuggestions(tags, suggestionsList) {
+        suggestionsList.innerHTML = '';
+        
+        if (tags.length === 0) {
+            suggestionsList.classList.add('hidden');
+            return;
+        }
+
+        tags.slice(0, 10).forEach(tag => {
+            const li = document.createElement('li');
+            li.className = 'px-3 py-2 hover:bg-gray-100 cursor-pointer text-sm';
+            li.textContent = tag.name;
+            
+            li.addEventListener('click', () => {
+                document.getElementById('tag_name').value = tag.name;
+                suggestionsList.classList.add('hidden');
+            });
+            
+            suggestionsList.appendChild(li);
+        });
+
+        suggestionsList.classList.remove('hidden');
+    }
+
+    showMessage(message, type = 'success') {
+        // Find the alert container (where session messages are displayed)
+        const alertContainer = document.querySelector('.max-w-4xl');
+        if (!alertContainer) return;
+        
+        // Create alert similar to the session alert component
+        const alertEl = document.createElement('div');
+        alertEl.setAttribute('x-data', '{ show: true }');
+        alertEl.setAttribute('x-show', 'show');
+        alertEl.setAttribute('x-transition:enter', 'transition ease-out duration-300');
+        alertEl.setAttribute('x-transition:enter-start', 'opacity-0 transform scale-90');
+        alertEl.setAttribute('x-transition:enter-end', 'opacity-100 transform scale-100');
+        alertEl.setAttribute('x-transition:leave', 'transition ease-in duration-300');
+        alertEl.setAttribute('x-transition:leave-start', 'opacity-100 transform scale-100');
+        alertEl.setAttribute('x-transition:leave-end', 'opacity-0 transform scale-90');
+        
+        if (type === 'success') {
+            alertEl.className = 'mb-4 p-4 bg-green-100 border border-green-400 text-green-700 rounded-lg flex items-center justify-between';
+            alertEl.innerHTML = `
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+                    </svg>
+                    ${message}
+                </div>
+                <button onclick="this.parentElement.remove()" class="text-green-700 hover:text-green-900">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                    </svg>
+                </button>
+            `;
+        } else {
+            alertEl.className = 'mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg flex items-center justify-between';
+            alertEl.innerHTML = `
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
+                    </svg>
+                    ${message}
+                </div>
+                <button onclick="this.parentElement.remove()" class="text-red-700 hover:text-red-900">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                    </svg>
+                </button>
+            `;
+        }
+        
+        // Insert at the beginning of the content area (same place as session alerts)
+        alertContainer.insertBefore(alertEl, alertContainer.firstChild);
+        
+        // Auto-remove after 3 seconds
+        setTimeout(() => {
+            if (alertEl.parentNode) {
+                alertEl.remove();
+            }
+        }, 3000);
+    }
+
+    updateSidebar() {
+        // Update sidebar favorite tags after reordering
+        fetch('/api/favorite-tags')
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    const sidebarList = document.getElementById('sidebar-favorite-tags-list');
+                    if (sidebarList) {
+                        sidebarList.innerHTML = '';
+                        
+                        if (data.data.length > 0) {
+                            data.data.forEach(favoriteTag => {
+                                const button = document.createElement('button');
+                                button.className = 'block w-full text-left hover:bg-gray-700 rounded px-2 py-1 text-sm text-blue-200 hover:text-blue-100 favorite-tag-btn';
+                                button.setAttribute('data-tag', favoriteTag.tag.name);
+                                button.setAttribute('title', `「${favoriteTag.tag.name}」で検索`);
+                                button.textContent = favoriteTag.tag.name;
+                                
+                                // Re-add click handler for search
+                                button.addEventListener('click', (e) => {
+                                    e.preventDefault();
+                                    const tagName = button.dataset.tag;
+                                    const currentUrl = new URL(window.location);
+                                    currentUrl.searchParams.set('tag', tagName);
+                                    currentUrl.searchParams.delete('title');
+                                    window.location.href = currentUrl.toString();
+                                });
+                                
+                                sidebarList.appendChild(button);
+                            });
+                        } else {
+                            const emptyMessage = document.createElement('p');
+                            emptyMessage.className = 'text-xs text-gray-400';
+                            emptyMessage.textContent = 'お気に入りのタグがありません';
+                            sidebarList.appendChild(emptyMessage);
+                        }
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('Error updating sidebar:', error);
+            });
+    }
+}

--- a/private-wiki/resources/js/favorite-tags.js
+++ b/private-wiki/resources/js/favorite-tags.js
@@ -1,0 +1,25 @@
+export class FavoriteTagsController {
+    constructor() {
+        this.initializeFavoriteTagButtons();
+    }
+
+    initializeFavoriteTagButtons() {
+        const favoriteTagButtons = document.querySelectorAll('.favorite-tag-btn');
+        
+        favoriteTagButtons.forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.preventDefault();
+                const tagName = button.dataset.tag;
+                this.performTagSearch(tagName);
+            });
+        });
+    }
+
+    performTagSearch(tagName) {
+        const currentUrl = new URL(window.location);
+        currentUrl.searchParams.set('tag', tagName);
+        currentUrl.searchParams.delete('title');
+        
+        window.location.href = currentUrl.toString();
+    }
+}

--- a/private-wiki/resources/views/favorite-tags/manage.blade.php
+++ b/private-wiki/resources/views/favorite-tags/manage.blade.php
@@ -1,0 +1,113 @@
+@extends('layouts.app')
+
+@section('title', 'お気に入りタグの管理')
+
+@section('content')
+<div class="max-w-4xl mx-auto">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold text-gray-900 mb-2">お気に入りタグの管理</h1>
+        <p class="text-gray-600">お気に入りタグを追加・削除・並び替えできます</p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {{-- 現在のお気に入りタグ --}}
+        <div class="bg-white rounded-lg shadow-md p-6">
+            <h2 class="text-xl font-semibold text-gray-800 mb-4">現在のお気に入りタグ</h2>
+            
+            @if($favoriteTags->count() > 0)
+                <div id="favorite-tags-management-list" class="space-y-2">
+                    @foreach($favoriteTags as $favoriteTag)
+                        <div class="flex items-center justify-between p-3 bg-gray-50 rounded border favorite-tag-item" 
+                             data-id="{{ $favoriteTag->id }}" 
+                             draggable="true">
+                            <div class="flex items-center">
+                                <div class="drag-handle cursor-grab mr-3 text-gray-400 hover:text-gray-600 select-none" title="ドラッグして並び替え">
+                                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                                        <circle cx="4" cy="4" r="1"/>
+                                        <circle cx="12" cy="4" r="1"/>
+                                        <circle cx="4" cy="8" r="1"/>
+                                        <circle cx="12" cy="8" r="1"/>
+                                        <circle cx="4" cy="12" r="1"/>
+                                        <circle cx="12" cy="12" r="1"/>
+                                    </svg>
+                                </div>
+                                <span class="text-blue-600 font-medium">{{ $favoriteTag->tag->name }}</span>
+                            </div>
+                            <form method="POST" action="{{ route('favorite-tags.remove', $favoriteTag) }}" 
+                                  class="inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" 
+                                        class="text-red-600 hover:text-red-800 text-sm px-2 py-1 rounded hover:bg-red-50">
+                                    削除
+                                </button>
+                            </form>
+                        </div>
+                    @endforeach
+                </div>
+                
+                <div class="mt-4 text-xs text-gray-500">
+                    ドラッグ&ドロップで並び順を変更できます
+                </div>
+            @else
+                <p class="text-gray-500 text-center py-8">お気に入りのタグがありません</p>
+            @endif
+        </div>
+
+        {{-- タグ追加フォーム --}}
+        <div class="bg-white rounded-lg shadow-md p-6">
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="text-xl font-semibold text-gray-800">タグを追加</h2>
+                <span class="text-sm text-gray-500">
+                    {{ $favoriteTags->count() }}/5個
+                </span>
+            </div>
+            
+            @if($favoriteTags->count() >= 5)
+                <div class="bg-yellow-50 border border-yellow-200 rounded-md p-4 mb-4">
+                    <p class="text-yellow-800 text-sm">
+                        お気に入りタグは最大5個までです。新しいタグを追加するには、既存のタグを削除してください。
+                    </p>
+                </div>
+            @else
+                <form method="POST" action="{{ route('favorite-tags.add') }}" id="tag-add-form">
+                    @csrf
+                    <div class="mb-4">
+                        <label for="tag_name" class="block text-sm font-medium text-gray-700 mb-2">
+                            タグ名を入力
+                        </label>
+                        <div class="relative">
+                            <input type="text" 
+                                   name="tag_name" 
+                                   id="tag_name" 
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                   placeholder="タグ名を入力してください"
+                                   autocomplete="off">
+                            <ul id="tag-suggestions-list" class="absolute bg-white border w-full z-10 hidden max-h-40 overflow-y-auto"></ul>
+                        </div>
+                        @error('tag_name')
+                            <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                        @enderror
+                        <p class="mt-1 text-xs text-gray-500">
+                            既存のタグ名を入力するか、新しいタグ名を作成できます
+                        </p>
+                    </div>
+                    
+                    <button type="submit" 
+                            class="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-400 disabled:cursor-not-allowed">
+                        お気に入りに追加
+                    </button>
+                </form>
+            @endif
+        </div>
+    </div>
+
+    <div class="mt-8 text-center">
+        <a href="{{ url('/') }}" 
+           class="inline-flex items-center px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700">
+            ← ホームに戻る
+        </a>
+    </div>
+</div>
+@endsection
+

--- a/private-wiki/resources/views/layouts/app.blade.php
+++ b/private-wiki/resources/views/layouts/app.blade.php
@@ -23,10 +23,30 @@
         </div>
         <nav class="space-y-2">
             <a href="{{ url('/') }}" class="block hover:bg-gray-700 rounded px-2 py-1">ホーム</a>
-            <a href="#" class="block hover:bg-gray-700 rounded px-2 py-1">メモ一覧</a>
             <a href="{{ route('bug-timeline.index') }}" class="block hover:bg-gray-700 rounded px-2 py-1">🐛 バグタイムライン</a>
+            <a href="{{ route('favorite-tags.manage') }}" class="block hover:bg-gray-700 rounded px-2 py-1">⭐ タグ管理</a>
             <a href="#" class="block hover:bg-gray-700 rounded px-2 py-1">設定</a>
         </nav>
+        
+        {{-- お気に入りタグセクション --}}
+        <div class="mt-6 pt-4 border-t border-gray-700" id="favorite-tags-section">
+            <h3 class="text-sm font-semibold text-gray-300 mb-3">お気に入りタグ</h3>
+            <div id="sidebar-favorite-tags-list" class="space-y-1">
+                @if(isset($favoriteTags) && $favoriteTags->count() > 0)
+                    @foreach($favoriteTags as $favoriteTag)
+                        <button 
+                            class="block w-full text-left hover:bg-gray-700 rounded px-2 py-1 text-sm text-blue-200 hover:text-blue-100 favorite-tag-btn"
+                            data-tag="{{ $favoriteTag->tag->name }}"
+                            title="「{{ $favoriteTag->tag->name }}」で検索"
+                        >
+                            {{ $favoriteTag->tag->name }}
+                        </button>
+                    @endforeach
+                @else
+                    <p class="text-xs text-gray-400">お気に入りのタグがありません</p>
+                @endif
+            </div>
+        </div>
         
         {{-- ユーザー情報とログアウト --}}
         @auth

--- a/private-wiki/routes/web.php
+++ b/private-wiki/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\BugTimelineController;
+use App\Http\Controllers\FavoriteTagController;
 use App\Http\Controllers\NoteController;
 use App\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
@@ -25,6 +26,17 @@ Route::middleware('auth')->group(function () {
     
     // タグ候補API
     Route::get('/tags', [TagController::class, 'index']);
+    
+    // お気に入りタグAPI
+    Route::get('/api/favorite-tags', [FavoriteTagController::class, 'index']);
+    Route::post('/api/favorite-tags', [FavoriteTagController::class, 'store']);
+    Route::delete('/api/favorite-tags/{favoriteTag}', [FavoriteTagController::class, 'destroy']);
+    Route::put('/api/favorite-tags/reorder', [FavoriteTagController::class, 'reorder']);
+    
+    // お気に入りタグ管理
+    Route::get('/favorite-tags/manage', [FavoriteTagController::class, 'manage'])->name('favorite-tags.manage');
+    Route::post('/favorite-tags/manage/add', [FavoriteTagController::class, 'add'])->name('favorite-tags.add');
+    Route::delete('/favorite-tags/manage/{favoriteTag}', [FavoriteTagController::class, 'remove'])->name('favorite-tags.remove');
     
     // バグタイムライン
     Route::get('/bug-timeline', [BugTimelineController::class, 'index'])->name('bug-timeline.index');

--- a/private-wiki/tests/Feature/FavoriteTagControllerTest.php
+++ b/private-wiki/tests/Feature/FavoriteTagControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoriteTagControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_get_favorite_tags_list()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag1 = Tag::factory()->create(['name' => 'Laravel']);
+        $tag2 = Tag::factory()->create(['name' => 'Vue.js']);
+        
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 2]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 1]);
+
+        $response = $this->get('/api/favorite-tags');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    [
+                        'id' => 2,
+                        'tag' => ['name' => 'Vue.js'],
+                        'display_order' => 1
+                    ],
+                    [
+                        'id' => 1,
+                        'tag' => ['name' => 'Laravel'],
+                        'display_order' => 2
+                    ]
+                ]
+            ]);
+    }
+
+    public function test_can_add_favorite_tag()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create(['name' => 'PHP']);
+
+        $response = $this->post('/api/favorite-tags', [
+            'tag_id' => $tag->id
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    'tag_id' => $tag->id,
+                    'display_order' => 1
+                ]
+            ]);
+
+        $this->assertDatabaseHas('favorite_tags', [
+            'tag_id' => $tag->id,
+            'display_order' => 1
+        ]);
+    }
+
+    public function test_cannot_add_duplicate_favorite_tag()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create();
+        FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $response = $this->postJson('/api/favorite-tags', [
+            'tag_id' => $tag->id
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_can_delete_favorite_tag()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create();
+        $favoriteTag = FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $response = $this->delete("/api/favorite-tags/{$favoriteTag->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'お気に入りタグを削除しました'
+            ]);
+
+        $this->assertDatabaseMissing('favorite_tags', [
+            'id' => $favoriteTag->id
+        ]);
+    }
+
+    public function test_can_reorder_favorite_tags()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        $tag3 = Tag::factory()->create();
+
+        $favorite1 = FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 1]);
+        $favorite2 = FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 2]);
+        $favorite3 = FavoriteTag::factory()->create(['tag_id' => $tag3->id, 'display_order' => 3]);
+
+        $response = $this->put('/api/favorite-tags/reorder', [
+            'favorite_tag_ids' => [$favorite3->id, $favorite1->id, $favorite2->id]
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'お気に入りタグの順序を変更しました'
+            ]);
+
+        $this->assertDatabaseHas('favorite_tags', ['id' => $favorite3->id, 'display_order' => 1]);
+        $this->assertDatabaseHas('favorite_tags', ['id' => $favorite1->id, 'display_order' => 2]);
+        $this->assertDatabaseHas('favorite_tags', ['id' => $favorite2->id, 'display_order' => 3]);
+    }
+
+    public function test_add_favorite_tag_requires_tag_id()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/favorite-tags', []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_add_favorite_tag_requires_valid_tag_id()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/favorite-tags', [
+            'tag_id' => 999999
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_reorder_requires_favorite_tag_ids()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->putJson('/api/favorite-tags/reorder', []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_delete_nonexistent_favorite_tag_returns_404()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->delete('/api/favorite-tags/999999');
+
+        $response->assertStatus(404)
+            ->assertJson([
+                'status' => 'error',
+                'message' => 'お気に入りタグが見つかりません'
+            ]);
+    }
+}

--- a/private-wiki/tests/Feature/FavoriteTagManagementTest.php
+++ b/private-wiki/tests/Feature/FavoriteTagManagementTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoriteTagManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_access_favorite_tags_management_page()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/favorite-tags/manage');
+
+        $response->assertStatus(200)
+            ->assertSee('お気に入りタグの管理')
+            ->assertSee('タグを追加');
+    }
+
+    public function test_management_page_displays_existing_favorite_tags()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag1 = Tag::factory()->create(['name' => 'Laravel']);
+        $tag2 = Tag::factory()->create(['name' => 'Vue.js']);
+        
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 1]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 2]);
+
+        $response = $this->get('/favorite-tags/manage');
+
+        $response->assertStatus(200)
+            ->assertSee('Laravel')
+            ->assertSee('Vue.js')
+            ->assertSee('削除', false);
+    }
+
+    public function test_management_page_shows_tag_input_for_addition()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/favorite-tags/manage');
+
+        $response->assertStatus(200)
+            ->assertSee('タグ名を入力')
+            ->assertSee('既存のタグ名を入力するか、新しいタグ名を作成できます');
+    }
+
+    public function test_can_add_favorite_tag_from_management_page()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->post('/favorite-tags/manage/add', [
+            'tag_name' => 'React'
+        ]);
+
+        $response->assertRedirect('/favorite-tags/manage')
+            ->assertSessionHas('success', 'お気に入りタグに追加しました');
+
+        $this->assertDatabaseHas('tags', [
+            'name' => 'React'
+        ]);
+
+        $tag = Tag::where('name', 'React')->first();
+        $this->assertDatabaseHas('favorite_tags', [
+            'tag_id' => $tag->id
+        ]);
+    }
+
+    public function test_can_remove_favorite_tag_from_management_page()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create();
+        $favoriteTag = FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $response = $this->delete("/favorite-tags/manage/{$favoriteTag->id}");
+
+        $response->assertRedirect('/favorite-tags/manage')
+            ->assertSessionHas('success', 'お気に入りタグから削除しました');
+
+        $this->assertDatabaseMissing('favorite_tags', [
+            'id' => $favoriteTag->id
+        ]);
+    }
+
+    public function test_management_page_requires_authentication()
+    {
+        $response = $this->get('/favorite-tags/manage');
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_management_page_shows_empty_state_when_no_favorites()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/favorite-tags/manage');
+
+        $response->assertStatus(200)
+            ->assertSee('お気に入りのタグがありません');
+    }
+
+    public function test_cannot_add_more_than_5_favorite_tags()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // 既に5個のお気に入りタグを作成
+        for ($i = 1; $i <= 5; $i++) {
+            $tag = Tag::factory()->create(['name' => "Tag{$i}"]);
+            FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+        }
+
+        $response = $this->post('/favorite-tags/manage/add', [
+            'tag_name' => 'ExtraTag'
+        ]);
+
+        $response->assertRedirect('/favorite-tags/manage')
+            ->assertSessionHas('error', 'お気に入りタグは最大5個までしか登録できません');
+    }
+
+    public function test_management_page_shows_limit_warning_when_at_max()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // 5個のお気に入りタグを作成
+        for ($i = 1; $i <= 5; $i++) {
+            $tag = Tag::factory()->create(['name' => "Tag{$i}"]);
+            FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+        }
+
+        $response = $this->get('/favorite-tags/manage');
+
+        $response->assertStatus(200)
+            ->assertSee('5/5個')
+            ->assertSee('お気に入りタグは最大5個までです');
+    }
+
+    public function test_can_add_existing_tag_by_name()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $existingTag = Tag::factory()->create(['name' => 'ExistingTag']);
+
+        $response = $this->post('/favorite-tags/manage/add', [
+            'tag_name' => 'ExistingTag'
+        ]);
+
+        $response->assertRedirect('/favorite-tags/manage')
+            ->assertSessionHas('success', 'お気に入りタグに追加しました');
+
+        $this->assertDatabaseHas('favorite_tags', [
+            'tag_id' => $existingTag->id
+        ]);
+    }
+
+    public function test_cannot_add_duplicate_favorite_tag_by_name()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create(['name' => 'DuplicateTag']);
+        FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $response = $this->post('/favorite-tags/manage/add', [
+            'tag_name' => 'DuplicateTag'
+        ]);
+
+        $response->assertRedirect('/favorite-tags/manage')
+            ->assertSessionHas('error', 'このタグは既にお気に入りに登録されています');
+    }
+}

--- a/private-wiki/tests/Feature/JavaScriptSearchTest.php
+++ b/private-wiki/tests/Feature/JavaScriptSearchTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JavaScriptSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_favorite_tag_click_triggers_search()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create(['name' => 'Laravel']);
+        FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $response = $this->get('/');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('favorite-tag-btn', $content);
+        $this->assertStringContainsString('data-tag="Laravel"', $content);
+    }
+
+    public function test_favorite_tag_search_redirects_to_correct_url()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/?tag=Laravel');
+
+        $response->assertStatus(200);
+        $this->assertEquals('Laravel', request('tag'));
+    }
+
+    public function test_multiple_favorite_tags_have_correct_data_attributes()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag1 = Tag::factory()->create(['name' => 'PHP']);
+        $tag2 = Tag::factory()->create(['name' => 'JavaScript']);
+        
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 1]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 2]);
+
+        $response = $this->get('/');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('data-tag="PHP"', $content);
+        $this->assertStringContainsString('data-tag="JavaScript"', $content);
+    }
+}

--- a/private-wiki/tests/Feature/SidebarTest.php
+++ b/private-wiki/tests/Feature/SidebarTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SidebarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sidebar_displays_favorite_tags()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag1 = Tag::factory()->create(['name' => 'Laravel']);
+        $tag2 = Tag::factory()->create(['name' => 'Vue.js']);
+        
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 2]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 1]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200)
+            ->assertSee('お気に入りタグ')
+            ->assertSee('Vue.js')
+            ->assertSee('Laravel');
+    }
+
+    public function test_sidebar_shows_no_favorites_message_when_empty()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200)
+            ->assertSee('お気に入りのタグがありません');
+    }
+
+    public function test_sidebar_favorite_tags_are_clickable()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag = Tag::factory()->create(['name' => 'Laravel']);
+        FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200)
+            ->assertSee('data-tag="Laravel"', false);
+    }
+
+    public function test_favorite_tags_are_ordered_by_display_order()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $tag1 = Tag::factory()->create(['name' => 'PHP']);
+        $tag2 = Tag::factory()->create(['name' => 'JavaScript']);
+        $tag3 = Tag::factory()->create(['name' => 'Python']);
+
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 3]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 1]);
+        FavoriteTag::factory()->create(['tag_id' => $tag3->id, 'display_order' => 2]);
+
+        $response = $this->get('/');
+        $content = $response->getContent();
+
+        $jsPosition = strpos($content, 'JavaScript');
+        $pythonPosition = strpos($content, 'Python');
+        $phpPosition = strpos($content, 'PHP');
+
+        $this->assertTrue($jsPosition < $pythonPosition);
+        $this->assertTrue($pythonPosition < $phpPosition);
+    }
+}

--- a/private-wiki/tests/Unit/FavoriteTagTest.php
+++ b/private-wiki/tests/Unit/FavoriteTagTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\FavoriteTag;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoriteTagTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_favorite_tag_can_be_created()
+    {
+        $tag = Tag::factory()->create(['name' => 'Laravel']);
+        
+        $favoriteTag = FavoriteTag::create([
+            'tag_id' => $tag->id,
+            'display_order' => 1
+        ]);
+
+        $this->assertInstanceOf(FavoriteTag::class, $favoriteTag);
+        $this->assertEquals($tag->id, $favoriteTag->tag_id);
+        $this->assertEquals(1, $favoriteTag->display_order);
+    }
+
+    public function test_favorite_tag_belongs_to_tag()
+    {
+        $tag = Tag::factory()->create(['name' => 'Vue.js']);
+        $favoriteTag = FavoriteTag::factory()->create([
+            'tag_id' => $tag->id
+        ]);
+
+        $this->assertInstanceOf(Tag::class, $favoriteTag->tag);
+        $this->assertEquals('Vue.js', $favoriteTag->tag->name);
+    }
+
+    public function test_favorite_tags_are_ordered_by_display_order()
+    {
+        $tag1 = Tag::factory()->create(['name' => 'PHP']);
+        $tag2 = Tag::factory()->create(['name' => 'JavaScript']);
+        $tag3 = Tag::factory()->create(['name' => 'Python']);
+
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 3]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 1]);
+        FavoriteTag::factory()->create(['tag_id' => $tag3->id, 'display_order' => 2]);
+
+        $favoriteTags = FavoriteTag::ordered()->get();
+
+        $this->assertEquals('JavaScript', $favoriteTags->first()->tag->name);
+        $this->assertEquals('Python', $favoriteTags->get(1)->tag->name);
+        $this->assertEquals('PHP', $favoriteTags->last()->tag->name);
+    }
+
+    public function test_can_get_next_display_order()
+    {
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        
+        FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 1]);
+        FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 3]);
+
+        $nextOrder = FavoriteTag::getNextDisplayOrder();
+        
+        $this->assertEquals(4, $nextOrder);
+    }
+
+    public function test_get_next_display_order_returns_1_when_no_favorites_exist()
+    {
+        $nextOrder = FavoriteTag::getNextDisplayOrder();
+        
+        $this->assertEquals(1, $nextOrder);
+    }
+
+    public function test_can_reorder_favorite_tags()
+    {
+        $tag1 = Tag::factory()->create();
+        $tag2 = Tag::factory()->create();
+        $tag3 = Tag::factory()->create();
+
+        $favorite1 = FavoriteTag::factory()->create(['tag_id' => $tag1->id, 'display_order' => 1]);
+        $favorite2 = FavoriteTag::factory()->create(['tag_id' => $tag2->id, 'display_order' => 2]);
+        $favorite3 = FavoriteTag::factory()->create(['tag_id' => $tag3->id, 'display_order' => 3]);
+
+        FavoriteTag::reorderTags([$favorite3->id, $favorite1->id, $favorite2->id]);
+
+        $this->assertEquals(1, $favorite3->fresh()->display_order);
+        $this->assertEquals(2, $favorite1->fresh()->display_order);
+        $this->assertEquals(3, $favorite2->fresh()->display_order);
+    }
+
+    public function test_tag_id_must_be_unique()
+    {
+        $tag = Tag::factory()->create();
+        
+        FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        FavoriteTag::factory()->create(['tag_id' => $tag->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- GitHub Issue #31「サイドバーに好きなタグを設定して、そのタグを押すと勝手にタイムラインをタグ検索できるようにしたい」の実装
- TDD（テスト駆動開発）アプローチで開発し、48個のテストが全てパス
- サイドバーにお気に入りタグを表示し、クリックでタグ検索が可能
- 管理画面でお気に入りタグの追加・削除・並び替えが可能（最大5個まで）
- オートコンプリート機能付きタグ入力
- ドラッグ&ドロップによる並び替え機能

## Test plan
- [x] 48個のテストケースが全て通過することを確認
- [x] サイドバーでお気に入りタグが表示されることを確認
- [x] お気に入りタグをクリックしてタグ検索が動作することを確認  
- [x] 管理画面でタグの追加・削除・並び替えが正常に動作することを確認
- [x] 5個制限が正しく機能することを確認
- [x] オートコンプリート機能が動作することを確認
- [x] ドラッグ&ドロップ並び替えが動作することを確認
- [x] レスポンシブデザインが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)