### PR TITLE
[Issue #26] 記事作成画面の内容欄プレイスホルダーを改善

### DIFF
--- a/private-wiki/resources/js/markdown-editor.js
+++ b/private-wiki/resources/js/markdown-editor.js
@@ -17,6 +17,8 @@ export class MarkdownEditor {
     this.handleInput = this.handleInput.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.updateHoverTitle = this.updateHoverTitle.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
 
     this.init();
   }
@@ -26,6 +28,8 @@ export class MarkdownEditor {
     this.editor.addEventListener('keyup', this.handleKeyup);
     this.editor.addEventListener('input', this.handleInput);
     this.editor.addEventListener('click', this.handleClick);
+    this.editor.addEventListener('focus', this.handleFocus);
+    this.editor.addEventListener('blur', this.handleBlur);
 
     if (this.form) {
       this.form.addEventListener('submit', () => {
@@ -87,7 +91,6 @@ export class MarkdownEditor {
   }
 
   handleInput() {
-    this.updatePlaceholder();
     const currentLine = this.getCurrentLine();
     if (currentLine) {
       const currentText = currentLine.textContent || '';
@@ -95,6 +98,17 @@ export class MarkdownEditor {
       this.updateHoverTitle(currentLine, currentText);
     }
     this.updateHiddenInput();
+    this.updatePlaceholder();
+  }
+
+  handleFocus() {
+    this.editor.classList.add('is-focused');
+    this.updatePlaceholder();
+  }
+
+  handleBlur() {
+    this.editor.classList.remove('is-focused');
+    this.updatePlaceholder();
   }
 
   handleClick(event) {

--- a/private-wiki/resources/views/notes/create.blade.php
+++ b/private-wiki/resources/views/notes/create.blade.php
@@ -58,7 +58,7 @@
     </form>
 
     <style>
-        #body-editor.empty:before {
+        #body-editor.empty:not(.is-focused):before {
             content: attr(data-placeholder);
             color: #9ca3af;
             pointer-events: none;

--- a/private-wiki/resources/views/notes/edit.blade.php
+++ b/private-wiki/resources/views/notes/edit.blade.php
@@ -53,7 +53,7 @@
     </form>
 
     <style>
-        #body-editor.empty:before {
+        #body-editor.empty:not(.is-focused):before {
             content: attr(data-placeholder);
             color: #9ca3af;
             pointer-events: none;

--- a/private-wiki/tests/js/markdown-editor.test.js
+++ b/private-wiki/tests/js/markdown-editor.test.js
@@ -4,7 +4,7 @@ describe('MarkdownEditor の行変換', () => {
   const setup = ({ initialBody = '' } = {}) => {
     document.body.innerHTML = `
       <form>
-        <div id="body-editor"></div>
+        <div id="body-editor" data-placeholder="プレースホルダー"></div>
         <input type="hidden" id="body" value="">
       </form>
     `;
@@ -22,7 +22,7 @@ describe('MarkdownEditor の行変換', () => {
       form,
     });
 
-    return { editor, markdownEditor };
+    return { editor, hiddenInput, markdownEditor };
   };
 
   afterEach(() => {
@@ -204,6 +204,53 @@ describe('MarkdownEditor の行変換', () => {
     expect(line.classList.contains('markdown-rendered')).toBe(true);
     expect(line.innerHTML).toContain('<h1');
     expect(line.getAttribute('title')).toBe('# 見出し');
+  });
+
+  test('入力を全て削除するとプレースホルダーが再表示される', () => {
+    const { editor, hiddenInput } = setup();
+    const line = editor.querySelector('.editor-line');
+
+    expect(editor.classList.contains('empty')).toBe(true);
+
+    const setCaretToLine = () => {
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(line);
+      range.collapse(false);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    };
+
+    line.textContent = 'サンプル';
+    setCaretToLine();
+    editor.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(editor.classList.contains('empty')).toBe(false);
+    expect(hiddenInput.value).toBe('サンプル');
+
+    line.textContent = '';
+    setCaretToLine();
+    editor.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(hiddenInput.value).toBe('');
+    expect(editor.classList.contains('empty')).toBe(true);
+  });
+
+  test('フォーカス時はプレースホルダーを隠すためのクラスが付与される', () => {
+    const { editor } = setup();
+
+    expect(editor.classList.contains('empty')).toBe(true);
+    expect(editor.classList.contains('is-focused')).toBe(false);
+
+    editor.dispatchEvent(new Event('focus'));
+
+    expect(editor.classList.contains('is-focused')).toBe(true);
+    expect(editor.classList.contains('empty')).toBe(true);
+
+    editor.dispatchEvent(new Event('blur'));
+
+    expect(editor.classList.contains('is-focused')).toBe(false);
+    expect(editor.classList.contains('empty')).toBe(true);
   });
 
 });


### PR DESCRIPTION
記事作成・編集画面の内容欄プレースホルダーを input の挙動に合わせて改善しました。\n\nCloses #26