### PR TITLE
[Issue #48] mdファイル読み込みボタンの影響範囲の修正

### DIFF
--- a/private-wiki/resources/views/notes/create.blade.php
+++ b/private-wiki/resources/views/notes/create.blade.php
@@ -32,9 +32,26 @@
         {{-- Markdownファイル読み込み --}}
         <div class="mb-6">
             <label class="block text-gray-700 font-bold mb-2" for="markdown-file">Markdownファイルから読み込み</label>
-            <input type="file" id="markdown-file" accept=".md,text/markdown" class="block w-full md:w-auto text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-600 hover:file:bg-blue-100">
-            <p id="markdown-file-name" class="text-sm text-gray-500 mt-1"></p>
-            <p id="markdown-import-error" class="text-sm text-red-500 hidden mt-1"></p>
+            <div class="flex flex-wrap items-center gap-3">
+                <button
+                    type="button"
+                    id="import-markdown"
+                    data-testid="markdown-file-trigger"
+                    class="inline-flex items-center gap-2 rounded border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-600 transition-colors duration-200 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    aria-controls="markdown-file"
+                >
+                    ファイルを選択
+                </button>
+                <span id="markdown-file-name" class="text-sm text-gray-500"></span>
+            </div>
+            <input
+                type="file"
+                id="markdown-file"
+                data-testid="markdown-file-input"
+                accept=".md,text/markdown"
+                class="hidden"
+            >
+            <p id="markdown-import-error" class="text-sm text-red-500 hidden mt-2"></p>
             <p class="text-xs text-gray-500 mt-1">ファイルを選択すると自動的にエディタへ読み込まれます。データはサーバーへアップロードされません。</p>
         </div>
 

--- a/private-wiki/tests/Feature/NoteMarkdownImportUiTest.php
+++ b/private-wiki/tests/Feature/NoteMarkdownImportUiTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NoteMarkdownImportUiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_markdown_file_selection_is_limited_to_button_area(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('notes.create'));
+
+        $response->assertOk();
+
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($response->getContent());
+        libxml_clear_errors();
+
+        $xpath = new DOMXPath($dom);
+
+        $fileInputNodes = $xpath->query('//*[@id="markdown-file"]');
+        $this->assertSame(1, $fileInputNodes->length, 'markdown-file input should be rendered');
+        $fileInputClass = $fileInputNodes->item(0)->getAttribute('class');
+        $this->assertMatchesRegularExpression('/(^|\\s)(hidden|sr-only)(\\s|$)/', $fileInputClass, 'markdown-file input should be visually hidden');
+
+        $triggerNodes = $xpath->query('//*[@data-testid="markdown-file-trigger"]');
+        $this->assertSame(1, $triggerNodes->length, 'markdown file trigger button should be rendered');
+        $this->assertSame('button', strtolower($triggerNodes->item(0)->nodeName), 'trigger should be a button element');
+
+        $buttonLabelNodes = $xpath->query('//button[normalize-space(text())="ファイルを選択"]');
+        $this->assertSame(1, $buttonLabelNodes->length, 'only one visible ファイルを選択 button should exist');
+    }
+}


### PR DESCRIPTION
mdファイル読み込みボタンのクリック可能範囲が広がりすぎていた問題を、ボタン内部に限定するよう修正しました。\n\n- UIをボタン+非表示ファイル入力構成に変更\n- DOM検証用Featureテストを追加\n\nCloses #48