### PR TITLE
[Issue #54] ハンバーガーマークを押しても、サイドメニューバーが最小化しない

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,8 +5,7 @@ import { FavoriteTagsManagement } from './favorite-tags-management.js';
 import { MarkdownEditor } from './markdown-editor.js';
 import { setupMarkdownImport } from './markdown-importer.js';
 
-// DOM読み込み完了後にコントローラーを初期化
-document.addEventListener('DOMContentLoaded', () => {
+const initializeApp = () => {
     new SidebarController();
     new FavoriteTagsController();
     
@@ -46,4 +45,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     }
-});
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeApp);
+} else {
+    initializeApp();
+}

--- a/tests/js/sidebar.test.js
+++ b/tests/js/sidebar.test.js
@@ -40,6 +40,31 @@ describe('SidebarController', () => {
     jest.clearAllMocks();
   });
 
+  const renderSidebarDom = () => {
+    document.body.innerHTML = `
+      <aside id="sidebar" class="w-64 h-screen fixed top-0 left-0 bg-gray-800 text-white px-4 py-6">
+        <h2 class="text-2xl font-bold mb-6">📚 Private Wiki</h2>
+        <button id="sidebar-toggle" class="absolute top-4 right-4 text-white hover:text-gray-300">
+          ☰
+        </button>
+        <nav class="space-y-2">
+          <a href="/" class="block hover:bg-gray-700 rounded px-2 py-1">ホーム</a>
+        </nav>
+      </aside>
+      <div id="main-content" class="ml-64 min-h-screen px-8 py-6">
+        <button id="main-sidebar-toggle" class="fixed top-4 left-4 z-50 bg-gray-800 hover:bg-gray-700 text-white p-2 rounded shadow-lg hidden">
+          ☰
+        </button>
+        <h1>メインコンテンツ</h1>
+      </div>
+    `;
+
+    mockSidebar = document.getElementById('sidebar');
+    mockMainContent = document.getElementById('main-content');
+    mockToggleButton = document.getElementById('sidebar-toggle');
+    mockMainToggleButton = document.getElementById('main-sidebar-toggle');
+  };
+
   describe('初期化', () => {
     test('SidebarControllerが正しくインスタンス化される', () => {
       expect(sidebarController).toBeInstanceOf(SidebarController);
@@ -60,6 +85,30 @@ describe('SidebarController', () => {
       const spy = jest.spyOn(sidebarController, 'toggle');
       mockMainToggleButton.click();
       expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('ローカルストレージが利用できない環境での挙動', () => {
+    test('localStorageアクセスが失敗してもハンバーガートグルが機能する', () => {
+      window.localStorage.getItem.mockImplementation(() => {
+        throw new Error('storage blocked');
+      });
+      window.localStorage.setItem.mockImplementation(() => {
+        throw new Error('storage blocked');
+      });
+
+      renderSidebarDom();
+
+      expect(() => {
+        sidebarController = new SidebarController();
+      }).not.toThrow();
+
+      mockToggleButton.click();
+      expect(mockSidebar.style.transform).toBe('translateX(-100%)');
+      expect(mockToggleButton.getAttribute('aria-expanded')).toBe('false');
+
+      window.localStorage.getItem.mockReset();
+      window.localStorage.setItem.mockReset();
     });
   });
 
@@ -138,7 +187,7 @@ describe('SidebarController', () => {
   describe('アクセシビリティ', () => {
     test('トグルボタンにaria-expanded属性が設定される', () => {
       expect(mockToggleButton.getAttribute('aria-expanded')).toBe('true');
-      
+
       sidebarController.toggle();
       expect(mockToggleButton.getAttribute('aria-expanded')).toBe('false');
     });
@@ -146,9 +195,26 @@ describe('SidebarController', () => {
     test('サイドバーにaria-hidden属性が設定される', () => {
       sidebarController.toggle();
       expect(mockSidebar.getAttribute('aria-hidden')).toBe('true');
-      
+
       sidebarController.expand();
       expect(mockSidebar.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    test('折り畳み時にフォーカスがメイン側トグルに移動する', () => {
+      mockToggleButton.focus();
+
+      sidebarController.collapse();
+
+      expect(document.activeElement).toBe(mockMainToggleButton);
+    });
+
+    test('折り畳み時はサイドバー側トグルがフォーカス不可能になる', () => {
+      sidebarController.collapse();
+
+      expect(mockToggleButton.getAttribute('tabindex')).toBe('-1');
+
+      sidebarController.expand();
+      expect(mockToggleButton.hasAttribute('tabindex')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## 変更概要
- サイドバー初期化処理をリファクタリングし、DOMContentLoaded前後で確実に起動するようにしました。
- localStorageが利用できない環境でも折り畳み状態の復元処理が失敗しないよう防御しました。
- 折り畳み時のフォーカス移動・aria属性更新・inert付与を追加し、支援技術での利用性を高めました。
- フォーカス制御やlocalStorageエラー時の挙動をカバーするJestテストを追加しました。

Closes #54